### PR TITLE
chore(alias): configure @/ alias for cross-module imports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,9 @@ git push origin feature/nom-clair
 - **Logique métier** → `src/engine/` uniquement
 - **UI / State** → `src/pages/` ou `src/features/`
 - **Pas de calcul fiscal dans les composants React**
-- Imports : chemins relatifs préférés aux alias `@/`
+- **Imports** :
+  - **`@/`** pour les imports cross-module / cross-feature (ex: `@/utils/`, `@/components/`)
+  - **Chemins relatifs** (`./`, `../`) OK pour les imports locaux (même dossier ou sous-dossier)
 
 ### TypeScript
 - Types importés depuis les **modules sources**, pas depuis les Providers

--- a/src/pptx/theme/semanticColors.ts
+++ b/src/pptx/theme/semanticColors.ts
@@ -15,7 +15,7 @@ import {
   WARNING, 
   pickTextColorForBackground,
   type ThemeTokens 
-} from '../../styles/semanticColors';
+} from '@/styles/semanticColors';
 
 // Re-export for convenience
 export { WHITE, WARNING, pickTextColorForBackground };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,10 @@
     "noFallthroughCasesInSwitch": true,
     "allowJs": true,
     "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "types": ["vite/client", "vitest/globals"]
   },
   "include": ["src"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, loadEnv } from 'vite'
+import path from 'path'
 
 // Debug flag for proxy logs (set to true for troubleshooting /api/admin)
 const DEBUG_PROXY = false;
@@ -22,6 +23,11 @@ export default defineConfig(({ mode }) => {
       // the component renders on direct refresh, causing layout issues.
       // Trade-off: slightly larger initial CSS bundle, but 100% style stability.
       cssCodeSplit: false,
+    },
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
     },
     server: {
       host: 'localhost',


### PR DESCRIPTION
- Add resolve.alias in vite.config.ts (@ -> ./src)
- Add baseUrl and paths in tsconfig.json (@/* -> ./src/*)
- Update CONTRIBUTING.md with @/ import rule (cross-module vs local)
- Revert semanticColors.ts to use @/ as validation test

## Summary
<!-- 1-2 lignes sur le changement -->

## Changes
<!-- Liste concise des fichiers/modules impactés -->
- 
- 

## Quality Gates (obligatoires)
- [ ] `npm run lint` passe (0 erreur ESLint)
- [ ] `npm run typecheck` passe (0 erreur TypeScript)
- [ ] `npm test` passe (71 tests Vitest)
- [ ] `npm run build` passe (build Vite OK)

## Documentation
- [ ] Pas de changement utilisateur visible
- [ ] README mis à jour (si nouveau feature)
- [ ] CONTRIBUTING mis à jour (si nouvelle convention)
- [ ] Changelog mis à jour (si breaking change ou feature majeure)

## Breaking Changes
- [ ] Non
- [ ] Oui (décrire ci-dessous + migration path)

## Screenshots / Démo
<!-- Si changement UI significatif -->

## Notes pour le reviewer
<!-- Points à vérifier en priorité -->
