### PR TITLE
Refactor UI PER Potentiel + améliorations textuelles

### DIFF
--- a/src/features/per/components/potentiel/PerPotentielSimulator.tsx
+++ b/src/features/per/components/potentiel/PerPotentielSimulator.tsx
@@ -2,7 +2,7 @@
  * PerPotentielSimulator - Wizard shell for "Contrôle du potentiel ER".
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import type { PerHistoricalBasis } from '../../../../engine/per';
 import { ExportMenu } from '../../../../components/ExportMenu';
 import { ModeToggle } from '../../../../components/ModeToggle';
@@ -10,6 +10,7 @@ import { useFiscalContext } from '../../../../hooks/useFiscalContext';
 import { useUserMode, type UserMode } from '../../../../settings/userMode';
 import { useTheme } from '../../../../settings/ThemeProvider';
 import '@/styles/sim/index.css';
+import { onResetEvent } from '../../../../utils/reset';
 import { usePerPotentiel, type WizardStep } from '../../hooks/usePerPotentiel';
 import { usePerPotentielExportHandlers } from '../../hooks/usePerPotentielExportHandlers';
 import { getPerWorkflowYears } from '../../utils/perWorkflowYears';
@@ -36,25 +37,6 @@ const fmtCurrency = (value: number): string =>
 const fmtPercent = (value: number): string =>
   `${(value <= 1 ? value * 100 : value).toFixed(1)} %`;
 
-function getDocumentBasisLabel(
-  mode: 'versement-n' | 'declaration-n1' | null,
-  basis: PerHistoricalBasis | null,
-  years: ReturnType<typeof getPerWorkflowYears>,
-): string {
-  if (mode === 'declaration-n1') {
-    return `Avis IR ${years.previousTaxYear} (revenus ${years.previousIncomeYear})`;
-  }
-
-  if (basis === 'current-avis') {
-    return `Avis IR ${years.currentTaxYear} (revenus ${years.currentIncomeYear})`;
-  }
-
-  if (basis === 'previous-avis-plus-n1') {
-    return `Avis IR ${years.previousTaxYear} (revenus ${years.previousIncomeYear}) + reconstitution ${years.currentIncomeYear}`;
-  }
-
-  return 'À définir';
-}
 
 function getStepMeta(
   stepId: WizardStep,
@@ -121,12 +103,18 @@ export default function PerPotentielSimulator(): React.ReactElement {
     updateSituation,
     updateDeclarant,
     setVersementEnvisage,
-    nextStep,
-    prevStep,
     goToStep,
-    canGoNext,
+    reset,
     isCouple,
   } = usePerPotentiel(fiscalContext);
+
+  useEffect(() => {
+    const off = onResetEvent(({ simId }: { simId?: string }) => {
+      if (simId && simId !== 'per-potentiel') return;
+      reset();
+    });
+    return off;
+  }, [reset]);
 
   const { exportExcel, exportPowerPoint, exportLoading } = usePerPotentielExportHandlers({
     state,
@@ -158,28 +146,37 @@ export default function PerPotentielSimulator(): React.ReactElement {
 
   const activeStep = getStepMeta(state.step, state.mode, state.historicalBasis, years);
   const stepIndex = visibleSteps.indexOf(state.step);
-  const currentPass = fiscalContext.passHistoryByYear[years.currentTaxYear] ?? null;
   const exportOptions = [
     { label: 'Excel', onClick: exportExcel, disabled: !result || state.step !== 5 },
     { label: 'PowerPoint', onClick: exportPowerPoint, disabled: !result || state.step !== 5 },
   ];
 
-  const pathLabel = state.mode === 'declaration-n1'
-    ? 'Déclaration 2042 N-1'
-    : state.mode === 'versement-n'
-      ? 'Contrôle avant versement N'
-      : 'À définir';
-  const documentLabel = getDocumentBasisLabel(state.mode, state.historicalBasis, years);
-  const projectionLabel = state.mode === 'versement-n'
-    ? (state.needsCurrentYearEstimate ? `Oui, revenus ${years.currentTaxYear}` : 'Non')
-    : 'Non';
-  const foyerLabel = isCouple
-    ? 'Couple marié ou pacsé'
-    : state.isole
-      ? 'Parent isolé'
-      : 'Personne seule';
-  const hasPrev = stepIndex > 0;
-  const hasNext = stepIndex >= 0 && stepIndex < visibleSteps.length - 1;
+  // Pills parcours dans la sidebar
+  type Pill = { label: string; on: boolean };
+  function buildPills(): Pill[] {
+    if (state.mode === 'declaration-n1') {
+      return [
+        { label: `Avis IR ${years.previousTaxYear}`, on: true },
+        { label: `Déclaration ${years.previousTaxYear}`, on: true },
+      ];
+    }
+    if (state.mode === 'versement-n') {
+      if (state.historicalBasis === 'current-avis') {
+        return [
+          { label: `Avis IR ${years.currentTaxYear}`, on: true },
+          { label: `Projection ${years.currentTaxYear}`, on: state.needsCurrentYearEstimate },
+        ];
+      }
+      return [
+        { label: `Avis IR ${years.previousTaxYear}`, on: true },
+        { label: `Reconstitution ${years.currentIncomeYear}`, on: true },
+        { label: `Projection ${years.currentTaxYear}`, on: state.needsCurrentYearEstimate },
+      ];
+    }
+    return [];
+  }
+  const parcoursPills = buildPills();
+
   const avisBasis = state.mode === 'declaration-n1'
     ? 'previous-avis-plus-n1'
     : state.historicalBasis ?? 'previous-avis-plus-n1';
@@ -187,15 +184,15 @@ export default function PerPotentielSimulator(): React.ReactElement {
   return (
     <div className="sim-page per-potentiel-page">
       <div className="premium-header sim-header sim-header--stacked">
-        <div className="per-potentiel-header-copy">
-          <h1 className="premium-title">Contrôle du potentiel épargne retraite</h1>
+        <h1 className="premium-title">Contrôle du potentiel épargne retraite</h1>
+        <div className="sim-header__subtitle-row">
           <p className="premium-subtitle">
             Mode, document fiscal, situation du foyer et restitution déclarative.
           </p>
-        </div>
-        <div className="sim-header__actions">
-          <ModeToggle value={isExpert} onChange={toggleMode} />
-          <ExportMenu options={exportOptions} loading={exportLoading} />
+          <div className="sim-header__actions">
+            <ModeToggle value={isExpert} onChange={toggleMode} />
+            <ExportMenu options={exportOptions} loading={exportLoading} />
+          </div>
         </div>
       </div>
 
@@ -225,29 +222,27 @@ export default function PerPotentielSimulator(): React.ReactElement {
 
       <div className="sim-grid">
         <main className="sim-grid__col">
+          {state.step === 1 ? (
+            <ModeStep
+              mode={state.mode}
+              historicalBasis={state.historicalBasis}
+              needsCurrentYearEstimate={state.needsCurrentYearEstimate}
+              years={years}
+              onSelectMode={setMode}
+              onSelectHistoricalBasis={setHistoricalBasis}
+              onSetNeedsCurrentYearEstimate={setNeedsCurrentYearEstimate}
+            />
+          ) : (
           <div className="premium-card premium-card--guide per-potentiel-stage">
             <div className="per-potentiel-stage-header sim-card__header--bleed">
               <h2 className="per-potentiel-stage-title">{activeStep.title}</h2>
             </div>
 
             <div className="per-potentiel-stage-body">
-              {state.step === 1 && (
-                <ModeStep
-                  mode={state.mode}
-                  historicalBasis={state.historicalBasis}
-                  needsCurrentYearEstimate={state.needsCurrentYearEstimate}
-                  years={years}
-                  onSelectMode={setMode}
-                  onSelectHistoricalBasis={setHistoricalBasis}
-                  onSetNeedsCurrentYearEstimate={setNeedsCurrentYearEstimate}
-                />
-              )}
-
               {state.step === 2 && (
                 <AvisIrStep
                   avisIr={state.avisIr}
                   avisIr2={state.avisIr2}
-                  isCouple={isCouple}
                   basis={avisBasis}
                   years={years}
                   onUpdate={updateAvisIr}
@@ -335,24 +330,8 @@ export default function PerPotentielSimulator(): React.ReactElement {
               )}
             </div>
 
-            {(hasPrev || hasNext) && (
-              <div className="per-potentiel-stage-footer">
-                {hasPrev ? (
-                  <button type="button" className="premium-btn" onClick={prevStep}>
-                    Retour
-                  </button>
-                ) : (
-                  <span />
-                )}
-
-                {hasNext && (
-                  <button type="button" className="premium-btn premium-btn-primary" onClick={nextStep} disabled={!canGoNext}>
-                    {visibleSteps[stepIndex + 1] === 5 ? 'Voir la synthèse' : 'Continuer'}
-                  </button>
-                )}
-              </div>
-            )}
           </div>
+          )}
         </main>
 
         {state.mode !== null && (
@@ -365,36 +344,25 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   <polyline points="14 2 14 8 20 8" />
                 </svg>
               </div>
-              <h3 className="sim-card__title">Dossier</h3>
+              <h3 className="sim-card__title">Potentiel</h3>
             </div>
             <div className="sim-divider" />
             <div className="per-potentiel-context-list">
-              <div className="per-potentiel-context-item">
-                <span className="per-potentiel-context-label">Parcours</span>
-                <span className="per-potentiel-context-value">{pathLabel}</span>
-              </div>
-              <div className="per-potentiel-context-item">
-                <span className="per-potentiel-context-label">Base documentaire</span>
-                <span className="per-potentiel-context-value">{documentLabel}</span>
-              </div>
-              <div className="per-potentiel-context-item">
-                <span className="per-potentiel-context-label">Projection {years.currentTaxYear}</span>
-                <span className="per-potentiel-context-value">{projectionLabel}</span>
-              </div>
-              <div className="per-potentiel-context-item">
-                <span className="per-potentiel-context-label">Foyer</span>
-                <span className="per-potentiel-context-value">{foyerLabel}</span>
-              </div>
-              <div className="per-potentiel-context-item">
-                <span className="per-potentiel-context-label">Parts</span>
-                <span className="per-potentiel-context-value">{state.nombreParts}</span>
-              </div>
-              <div className="per-potentiel-context-item">
-                <span className="per-potentiel-context-label">PASS {years.currentTaxYear}</span>
-                <span className="per-potentiel-context-value">
-                  {currentPass ? fmtCurrency(currentPass) : '—'}
-                </span>
-              </div>
+              {parcoursPills.length > 0 && (
+                <div className="per-potentiel-context-item">
+                  <span className="per-potentiel-context-label per-potentiel-context-label--small">Parcours</span>
+                  <div className="per-potentiel-pills">
+                    {parcoursPills.map((pill) => (
+                      <span
+                        key={pill.label}
+                        className={`per-potentiel-pill${pill.on ? ' is-on' : ''}`}
+                      >
+                        {pill.label}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
           </div>
 

--- a/src/features/per/components/potentiel/steps/AvisIrStep.tsx
+++ b/src/features/per/components/potentiel/steps/AvisIrStep.tsx
@@ -9,7 +9,6 @@ import { getAvisReferenceYears, type PerWorkflowYears } from '../../../utils/per
 interface AvisIrStepProps {
   avisIr: AvisIrPlafonds | null;
   avisIr2: AvisIrPlafonds | null;
-  isCouple: boolean;
   basis: PerHistoricalBasis;
   years: PerWorkflowYears;
   onUpdate: (_patch: Partial<AvisIrPlafonds>, _decl?: 1 | 2) => void;
@@ -45,10 +44,11 @@ function AvisFieldsCard({
 
   return (
     <div className="premium-card per-avis-form-card">
-      <div className="per-avis-form-header">
+      <div className="per-avis-form-header sim-card__header--bleed">
         <p className="premium-section-title">Saisie</p>
         <h4 className="per-avis-form-title">{label}</h4>
       </div>
+      <div className="sim-divider" />
 
       <div className="per-avis-row-list">
         {rows.map((row) => (
@@ -72,59 +72,16 @@ function AvisFieldsCard({
 export default function AvisIrStep({
   avisIr,
   avisIr2,
-  isCouple,
   basis,
   years,
   onUpdate,
 }: AvisIrStepProps): React.ReactElement {
   const avisContext = getAvisReferenceYears(years, basis);
+  const totalPlafond = (avisIr?.plafondCalcule ?? 0) + (avisIr2?.plafondCalcule ?? 0);
 
   return (
     <div className="per-step per-step--avis">
-      <div className="per-avis-layout">
-        <div className="premium-card-compact per-avis-guide-card">
-          <p className="premium-section-title">Ce qu'il faut relever</p>
-          <ol className="per-avis-checklist">
-            <li>Les trois années de plafond non utilisé.</li>
-            <li>Le plafond calculé sur les revenus {avisContext.incomeYear}.</li>
-            <li>Les montants déclarant par déclarant si le foyer est un couple.</li>
-          </ol>
-        </div>
-
-        <div className="premium-card per-avis-preview-card">
-          <div className="per-avis-preview">
-            <div className="per-avis-preview-header">
-              <div>
-                <p className="premium-section-title">Repérage visuel</p>
-                <h4 className="per-avis-preview-title">Avis d'impôt {avisContext.taxYear}</h4>
-              </div>
-              <span className="per-avis-preview-chip">Revenus {avisContext.incomeYear}</span>
-            </div>
-
-            <div className="per-avis-preview-sheet">
-              <div className="per-avis-preview-line per-avis-preview-line--muted">
-                Direction générale des finances publiques
-              </div>
-              <div className="per-avis-preview-line per-avis-preview-line--muted">
-                Avis établi en {avisContext.taxYear}
-              </div>
-              <div className="per-avis-preview-focus">
-                <span className="per-avis-preview-focus-label">Rubrique à lire</span>
-                <strong>PLAFOND ÉPARGNE RETRAITE</strong>
-              </div>
-              <div className="per-avis-preview-grid">
-                <div>Plafond total</div>
-                <div>Plafond non utilisé {avisContext.carryForwardYears[0]}</div>
-                <div>Plafond non utilisé {avisContext.carryForwardYears[1]}</div>
-                <div>Plafond non utilisé {avisContext.carryForwardYears[2]}</div>
-                <div>Plafond calculé sur revenus {avisContext.incomeYear}</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div className={`per-avis-form-grid ${isCouple ? 'is-couple' : ''}`}>
+      <div className={`per-avis-form-grid per-avis-form-grid--always-two`}>
         <AvisFieldsCard
           label="Déclarant 1"
           avis={avisIr}
@@ -133,15 +90,22 @@ export default function AvisIrStep({
           onChange={(patch) => onUpdate(patch, 1)}
         />
 
-        {isCouple && (
-          <AvisFieldsCard
-            label="Déclarant 2"
-            avis={avisIr2}
-            incomeYear={avisContext.incomeYear}
-            carryForwardYears={avisContext.carryForwardYears}
-            onChange={(patch) => onUpdate(patch, 2)}
-          />
-        )}
+        <AvisFieldsCard
+          label="Déclarant 2"
+          avis={avisIr2}
+          incomeYear={avisContext.incomeYear}
+          carryForwardYears={avisContext.carryForwardYears}
+          onChange={(patch) => onUpdate(patch, 2)}
+        />
+      </div>
+
+      <div className="per-avis-total-row">
+        <span className="per-avis-total-label">
+          Plafond pour les cotisations versées en {years.currentTaxYear}
+        </span>
+        <span className="per-avis-total-value">
+          {totalPlafond.toLocaleString('fr-FR')} €
+        </span>
       </div>
     </div>
   );

--- a/src/features/per/components/potentiel/steps/ModeStep.tsx
+++ b/src/features/per/components/potentiel/steps/ModeStep.tsx
@@ -17,21 +17,6 @@ interface ModeStepProps {
   onSetNeedsCurrentYearEstimate: (_value: boolean) => void;
 }
 
-const MODES: { id: PerMode; title: string; desc: string; marker: string }[] = [
-  {
-    id: 'versement-n',
-    title: 'Contrôle du potentiel avant versement',
-    desc: 'Je veux vérifier si un versement PER cette année reste déductible et quel gain fiscal il peut générer.',
-    marker: 'Versement N',
-  },
-  {
-    id: 'declaration-n1',
-    title: 'Contrôle de la déclaration 2042',
-    desc: "J'ai déjà versé et je veux fiabiliser les cases de déclaration et la lecture du potentiel restant.",
-    marker: 'Déclaration N-1',
-  },
-];
-
 export default function ModeStep({
   mode,
   historicalBasis,
@@ -41,12 +26,38 @@ export default function ModeStep({
   onSelectHistoricalBasis,
   onSetNeedsCurrentYearEstimate,
 }: ModeStepProps): React.ReactElement {
-  const showVersementChoices = mode === 'versement-n';
+  const modes: { id: PerMode; title: string; desc: string; marker: string }[] = [
+    {
+      id: 'versement-n',
+      title: 'Contrôle du potentiel avant versement',
+      desc: 'Vérifiez si un versement PER reste déductible et quel gain fiscal il peut générer',
+      marker: 'Versement N',
+    },
+    {
+      id: 'declaration-n1',
+      title: 'Reporter dans la déclaration 2042',
+      desc: `Visualisez comment reporter des versements ${years.previousTaxYear} dans la déclaration ${years.currentTaxYear} (sur les revenus ${years.previousIncomeYear})`,
+      marker: 'Déclaration N-1',
+    },
+  ];
 
   return (
     <div className="per-step per-step--mode">
+      <div className="premium-card sim-card--guide per-mode-step-card">
+        <div className="per-mode-step-header sim-card__header--bleed">
+          <div className="sim-card__title-row">
+            <div className="sim-card__icon">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+              </svg>
+            </div>
+            <h3 className="sim-card__title">Choix du parcours</h3>
+          </div>
+        </div>
+        <div className="sim-divider" />
+
       <div className="per-mode-grid">
-        {MODES.map((item) => (
+        {modes.map((item) => (
           <button
             key={item.id}
             type="button"
@@ -59,91 +70,103 @@ export default function ModeStep({
           </button>
         ))}
       </div>
-
-      <div className="premium-card per-mode-support-card per-mode-support-card--accent">
-        <p className="premium-section-title">Documents disponibles</p>
-
-        {showVersementChoices ? (
-          <div className="per-mode-panel-stack">
-            <div className="per-mode-panel-block">
-              <h4 className="per-mode-panel-title">Base documentaire de départ</h4>
-              <p className="per-mode-panel-text">
-                Choisissez l&apos;avis d&apos;impôt disponible. Le parcours ajoutera ensuite les écrans
-                nécessaires pour reconstituer les revenus utiles au calcul.
-              </p>
-              <div className="per-mode-doc-grid">
-                <button
-                  type="button"
-                  className={`per-mode-doc-card ${historicalBasis === 'previous-avis-plus-n1' ? 'is-selected' : ''}`}
-                  onClick={() => onSelectHistoricalBasis('previous-avis-plus-n1')}
-                >
-                  <span className="per-mode-doc-title">
-                    Avis IR {years.previousTaxYear} disponible
-                  </span>
-                  <span className="per-mode-doc-desc">
-                    Avis sur les revenus {years.previousIncomeYear}. Le simulateur reconstituera
-                    ensuite les revenus {years.currentIncomeYear} pour recalculer le plafond 163
-                    quatervicies.
-                  </span>
-                </button>
-
-                <button
-                  type="button"
-                  className={`per-mode-doc-card ${historicalBasis === 'current-avis' ? 'is-selected' : ''}`}
-                  onClick={() => onSelectHistoricalBasis('current-avis')}
-                >
-                  <span className="per-mode-doc-title">
-                    Avis IR {years.currentTaxYear} disponible
-                  </span>
-                  <span className="per-mode-doc-desc">
-                    Avis sur les revenus {years.currentIncomeYear}. Le plafond épargne retraite est
-                    déjà visible sur l&apos;avis ; vous pouvez passer directement aux versements de l&apos;année.
-                  </span>
-                </button>
-              </div>
-            </div>
-
-            <div className="per-mode-panel-block">
-              <h4 className="per-mode-panel-title">Faut-il projeter l'année en cours ?</h4>
-              <p className="per-mode-panel-text">
-                Activez l&apos;estimation {years.currentTaxYear} si vous devez intégrer des revenus ou
-                versements de l&apos;année en cours pour Madelin, PERCO, PEROB ou art. 83.
-              </p>
-              <div className="per-mode-doc-grid">
-                <button
-                  type="button"
-                  className={`per-mode-doc-card ${!needsCurrentYearEstimate ? 'is-selected' : ''}`}
-                  onClick={() => onSetNeedsCurrentYearEstimate(false)}
-                >
-                  <span className="per-mode-doc-title">Pas d'estimation {years.currentTaxYear}</span>
-                  <span className="per-mode-doc-desc">
-                    Je m'appuie sur les données déjà arrêtées et je ne projette pas de revenus
-                    complémentaires pour l'année en cours.
-                  </span>
-                </button>
-
-                <button
-                  type="button"
-                  className={`per-mode-doc-card ${needsCurrentYearEstimate ? 'is-selected' : ''}`}
-                  onClick={() => onSetNeedsCurrentYearEstimate(true)}
-                >
-                  <span className="per-mode-doc-title">Estimation {years.currentTaxYear} nécessaire</span>
-                  <span className="per-mode-doc-desc">
-                    Je dois projeter les revenus et versements {years.currentTaxYear} pour affiner les
-                    plafonds Madelin, PERCO, PEROB ou art. 83.
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-        ) : (
-          <div className="per-mode-declaration-note">
-            <strong>Point de départ retenu :</strong> avis IR {years.previousTaxYear} sur les revenus{' '}
-            {years.previousIncomeYear}, puis collecte des revenus {years.currentIncomeYear} exacts et
-            des versements réalisés en {years.currentIncomeYear}. L'étape Avis IR reste incluse.
-          </div>
-        )}
       </div>
+
+      {mode !== null && (
+        <div className="premium-card sim-card--guide per-mode-support-card">
+          <div className="per-mode-docs-header sim-card__header--bleed">
+            <div className="sim-card__title-row">
+              <div className="sim-card__icon">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                  <polyline points="14 2 14 8 20 8" />
+                </svg>
+              </div>
+              <h3 className="sim-card__title">Documents nécessaires</h3>
+            </div>
+            <p className="per-mode-docs-subtitle">Base documentaire de départ</p>
+          </div>
+          <div className="sim-divider" />
+
+          {mode === 'versement-n' ? (
+            <div className="per-mode-panel-stack">
+              <div className="per-mode-panel-block">
+                <div className="per-mode-doc-grid">
+                  <button
+                    type="button"
+                    className={`per-mode-doc-card ${historicalBasis === 'previous-avis-plus-n1' ? 'is-selected' : ''}`}
+                    onClick={() => onSelectHistoricalBasis('previous-avis-plus-n1')}
+                  >
+                    <span className="per-mode-doc-title">
+                      Avis IR {years.previousTaxYear} disponible
+                    </span>
+                    <span className="per-mode-doc-desc">
+                      Avis sur les revenus {years.previousIncomeYear}. Le simulateur reconstituera
+                      ensuite les revenus {years.currentIncomeYear} pour recalculer le plafond 163
+                      quatervicies.
+                    </span>
+                  </button>
+
+                  <button
+                    type="button"
+                    className={`per-mode-doc-card ${historicalBasis === 'current-avis' ? 'is-selected' : ''}`}
+                    onClick={() => onSelectHistoricalBasis('current-avis')}
+                  >
+                    <span className="per-mode-doc-title">
+                      Avis IR {years.currentTaxYear} disponible
+                    </span>
+                    <span className="per-mode-doc-desc">
+                      Avis sur les revenus {years.currentIncomeYear}. Le plafond épargne retraite est
+                      déjà visible sur l&apos;avis ; vous pouvez passer directement aux versements de l&apos;année.
+                    </span>
+                  </button>
+                </div>
+              </div>
+
+              <div className="per-mode-panel-block">
+                <div className="per-mode-toggle-row">
+                  <h4 className="per-mode-panel-title">Faut-il projeter l&apos;année en cours ?</h4>
+                  <button
+                    type="button"
+                    className={`mode-toggle-pill${needsCurrentYearEstimate ? ' mode-toggle-pill--active' : ''}`}
+                    onClick={() => onSetNeedsCurrentYearEstimate(!needsCurrentYearEstimate)}
+                    aria-pressed={needsCurrentYearEstimate}
+                    aria-label={`Activer l'estimation ${years.currentTaxYear}`}
+                  >
+                    <span className="mode-toggle-pill__knob" />
+                  </button>
+                </div>
+                {needsCurrentYearEstimate && (
+                  <p className="per-mode-toggle-hint">
+                    Activez l&apos;estimation {years.currentTaxYear} si vous devez intégrer des revenus ou
+                    versements de l&apos;année en cours pour Madelin, PERCO, PEROB ou art. 83. Il vous faudra
+                    estimer les revenus et les versements {years.currentTaxYear}.
+                  </p>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="per-mode-doc-grid">
+              <div className="per-mode-doc-card is-selected">
+                <span className="per-mode-doc-title">
+                  Avis IR {years.previousTaxYear} disponible
+                </span>
+                <span className="per-mode-doc-desc">
+                  Avis sur les revenus {years.previousIncomeYear}.
+                </span>
+              </div>
+              <div className="per-mode-doc-card is-selected">
+                <span className="per-mode-doc-title">
+                  Déclaration {years.previousTaxYear}
+                </span>
+                <span className="per-mode-doc-desc">
+                  Ensemble des revenus et versements épargne retraite {years.currentIncomeYear}.
+                </span>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/features/per/styles/steps.css
+++ b/src/features/per/styles/steps.css
@@ -1,5 +1,33 @@
 ﻿/* -- Mode step ------------------------------------------------------------ */
 
+.per-mode-step-header {
+  /* header standalone sans card parent */
+  margin-bottom: 0;
+}
+
+.per-mode-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.per-mode-toggle-hint {
+  font-size: 12px;
+  color: var(--color-c9);
+  margin-top: 6px;
+  line-height: 1.5;
+}
+
+.per-mode-docs-header {
+  /* sim-card__header--bleed gère le dégradé via la classe parente */
+}
+
+.per-mode-docs-subtitle {
+  font-size: 12px;
+  color: var(--color-c9);
+  margin-top: 4px;
+}
+
 .per-mode-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -53,8 +81,8 @@
 
 .per-mode-card-desc {
   margin: 0;
-  font-size: 13px;
-  line-height: 1.65;
+  font-size: 11px;
+  line-height: 1.5;
   color: var(--color-c9);
 }
 
@@ -62,9 +90,6 @@
   box-sizing: border-box;
 }
 
-.per-mode-support-card--accent {
-  border-left: 3px solid var(--color-c3);
-}
 
 .per-mode-panel-stack {
   display: grid;
@@ -103,7 +128,7 @@
   padding: 12px 14px;
   border: 1px solid var(--color-c8);
   border-radius: 10px;
-  background: var(--color-c7);
+  background: #FFFFFF;
   text-align: left;
   cursor: pointer;
   transition: border-color 0.2s, background-color 0.2s, transform 0.2s;
@@ -159,106 +184,6 @@
   background: var(--color-c7);
 }
 
-.per-avis-layout {
-  display: grid;
-  grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr);
-  gap: 16px;
-}
-
-.per-avis-guide-card {
-  border-left: 3px solid var(--color-c6);
-}
-
-.per-avis-checklist {
-  margin: 0;
-  padding-left: 20px;
-  display: grid;
-  gap: 10px;
-  font-size: 13px;
-  line-height: 1.6;
-  color: var(--color-c9);
-}
-
-.per-avis-preview-card {
-  box-sizing: border-box;
-}
-
-.per-avis-preview {
-  display: grid;
-  gap: 16px;
-}
-
-.per-avis-preview-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.per-avis-preview-title {
-  margin: 0;
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--color-c1);
-}
-
-.per-avis-preview-chip {
-  display: inline-flex;
-  align-items: center;
-  padding: 5px 10px;
-  border-radius: 999px;
-  background: var(--color-c7);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.8px;
-  text-transform: uppercase;
-  color: var(--color-c9);
-}
-
-.per-avis-preview-sheet {
-  display: grid;
-  gap: 10px;
-  padding: 18px;
-  border: 1px solid var(--color-c8);
-  border-radius: 12px;
-  background: color-mix(in srgb, var(--color-c7) 70%, #FFFFFF);
-}
-
-.per-avis-preview-line {
-  font-size: 12px;
-  color: var(--color-c1);
-}
-
-.per-avis-preview-line--muted {
-  color: var(--color-c9);
-}
-
-.per-avis-preview-focus {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 14px;
-  border-radius: 10px;
-  background: #FFFFFF;
-  border-left: 3px solid var(--color-c3);
-  color: var(--color-c1);
-}
-
-.per-avis-preview-focus-label {
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.8px;
-  text-transform: uppercase;
-  color: var(--color-c9);
-}
-
-.per-avis-preview-grid {
-  display: grid;
-  gap: 8px;
-  font-size: 12px;
-  line-height: 1.55;
-  color: var(--color-c9);
-}
 
 .per-avis-form-grid {
   display: grid;
@@ -266,7 +191,7 @@
   gap: 16px;
 }
 
-.per-avis-form-grid.is-couple {
+.per-avis-form-grid--always-two {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
@@ -275,7 +200,28 @@
 }
 
 .per-avis-form-header {
-  margin-bottom: 16px;
+  margin-bottom: 0;
+}
+
+/* Ligne totale plafond */
+.per-avis-total-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 0;
+  border-top: 1px solid var(--color-c8);
+  margin-top: 4px;
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--color-c1);
+}
+
+.per-avis-total-label {
+  color: var(--color-c1);
+}
+
+.per-avis-total-value {
+  font-variant-numeric: tabular-nums;
 }
 
 .per-avis-form-title {

--- a/src/features/per/styles/wizard.css
+++ b/src/features/per/styles/wizard.css
@@ -126,19 +126,33 @@
   color: var(--color-c9);
 }
 
-.per-potentiel-stage-footer {
-  display: flex;
-  justify-content: space-between;
-  gap: 16px;
-  margin-top: 24px;
-  padding-top: 18px;
-  border-top: 1px solid var(--color-c8);
+/* Pills parcours sidebar */
+.per-potentiel-context-label--small {
+  font-size: 11px;
 }
 
-.per-potentiel-stage-actions {
+.per-potentiel-pills {
   display: flex;
+  gap: 4px;
   flex-wrap: wrap;
-  gap: 12px;
+  margin-top: 4px;
+}
+
+.per-potentiel-pill {
+  font-size: 10px;
+  padding: 2px 7px;
+  border-radius: 999px;
+  border: 1px solid var(--color-c8);
+  color: var(--color-c9);
+  background: var(--color-c7);
+  white-space: nowrap;
+}
+
+.per-potentiel-pill.is-on {
+  background: color-mix(in srgb, var(--color-c3) 18%, #fff);
+  border-color: color-mix(in srgb, var(--color-c3) 45%, var(--color-c8));
+  color: var(--color-c1);
+  font-weight: 500;
 }
 
 .per-potentiel-context-card--accent {


### PR DESCRIPTION
## Description
Refactor de l'interface du simulateur PER Potentiel avec amélioration de la cohérence UX et des textes descriptifs.

## Changements
- PerPotentielSimulator.tsx — Header restructuré (sim-header__subtitle-row), step 1 extrait hors carte stage, sidebar renommée "Potentiel", Foyer/Parts/PASS supprimés, 3 lignes remplacées par des pills visuelles dynamiques
- ModeStep.tsx — Carte "Choix du parcours" avec icône + dégradé + sim-divider, mode renommé "Reporter dans la déclaration 2042" avec dates dynamiques, section "Documents nécessaires" avec icône/dégradé/sous-titre, toggle projection (2 boutons remplacés par 1 pill + hint), texte déclaration simplifié
- AvisIrStep.tsx — Blocs "Ce qu'il faut relever" et "Repérage visuel" supprimés, style Saisie corrigé (header dégradé + sim-divider), Déclarant 2 toujours affiché (grid always-two), ligne totale "Plafond pour les cotisations versées en {currentTaxYear}" ajoutée
- styles/steps.css — CSS orphelins supprimés (preview, guide, layout), styles pills/toggle/total-row ajoutés, per-mode-doc-card background blanc, per-mode-card-desc font-size 11px (aligné sur per-mode-doc-desc)

## Fonctionnalités
- Header plus cohérent avec succession/crédit (ModeToggle et Export alignés à droite)
- UX simplifiée : moins de blocs textuels, plus de visuels (pills, toggle)
- Sidebar dynamique : pills visuelles selon le mode sélectionné
- Textes descriptions mode cards ajustés et taille de police harmonisée

## Tests effectués
- [x] `npm run lint` passe
- [x] `npm run typecheck` passe
- [x] `npm test` passe (1558 tests)
- [x] `npm run build` passe
- [x] `npm run check` passe

## Notes
Pas de changement fonctionnel sur le calcul, uniquement UI/UX.
Rollback simple : revert le commit unique.

## Checklist
- [x] Pas de push direct sur `main`
- [x] Pas de fichiers temporaires ajoutés à la racine
- [x] Documentation mise à jour si nécessaire (non requise pour ce refactor UI)