### PR TITLE
fix(per-potentiel) : corrections UI bloc Versements retraite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,16 @@ Stack : React 18 + Vite + TypeScript strict + Supabase.
 Terminal : Windows/PowerShell — pas de commandes macOS/Linux.
 CI gate : `npm run check` — doit passer avant tout commit.
 
+## Posture développeur expérimenté (priorité absolue)
+
+Agir en développeur senior à chaque plan et chaque implémentation.
+
+- **Réutiliser avant d'ajouter** — identifier systématiquement ce qui existe déjà (hooks, utils, composants, types) et s'appuyer dessus plutôt que de dupliquer.
+- **Organisation cohérente** — si un ajout révèle un désalignement dans la structure du repo (mauvais emplacement, responsabilité mal placée, abstraction manquante), le signaler et l'inclure dans le plan.
+- **Plan minimal et propre** — un plan ne doit contenir que ce qui est nécessaire, mais doit inclure toute étape qu'un dev expérimenté jugerait indispensable : nettoyage, renommage, déplacement de fichier, suppression de code mort, cohérence de nommage.
+- **Pas de code jetable** — ne pas ajouter de lignes si on peut adapter ce qui existe. Chaque ajout doit avoir une justification claire.
+- **Propreté systématique** — si quelque chose doit être nettoyé pour que le résultat final soit propre, ajouter l'étape de nettoyage au plan plutôt que de laisser de la dette.
+
 ## Règles absolues (toujours actives)
 
 1. **Preuve obligatoire** — ne jamais affirmer « code mort », « non utilisé », « RLS OK »,

--- a/src/features/per/components/potentiel/PerAmountInput.tsx
+++ b/src/features/per/components/potentiel/PerAmountInput.tsx
@@ -4,6 +4,7 @@ import { formatIntegerInput } from '@/utils/formatNumber';
 interface PerAmountInputProps {
   value: number;
   onChange: (_value: number) => void;
+  ariaLabel?: string;
   label?: string;
   placeholder?: string;
   min?: number;
@@ -20,6 +21,7 @@ const parseInput = (raw: string): number => {
 export function PerAmountInput({
   value,
   onChange,
+  ariaLabel,
   label,
   placeholder = '0',
   min = 0,
@@ -56,6 +58,7 @@ export function PerAmountInput({
       inputMode="numeric"
       className={`per-input sim-field__control ${className}`.trim()}
       value={displayValue}
+      aria-label={ariaLabel}
       placeholder={placeholder}
       onFocus={handleFocus}
       onBlur={handleBlur}

--- a/src/features/per/components/potentiel/PerPotentielSimulator.test.tsx
+++ b/src/features/per/components/potentiel/PerPotentielSimulator.test.tsx
@@ -94,55 +94,81 @@ const fmtCurrency = (value: number): string =>
     maximumFractionDigits: 0,
   }).format(value);
 
+function makeHookState(step: number) {
+  return {
+    step,
+    mode: 'versement-n',
+    historicalBasis: 'previous-avis-plus-n1',
+    needsCurrentYearEstimate: false,
+    avisIr: {
+      nonUtiliseAnnee1: 2000,
+      nonUtiliseAnnee2: 3000,
+      nonUtiliseAnnee3: 1500,
+      plafondCalcule: 4500,
+      anneeRef: 2024,
+    },
+    avisIr2: {
+      nonUtiliseAnnee1: 1000,
+      nonUtiliseAnnee2: 2000,
+      nonUtiliseAnnee3: 500,
+      plafondCalcule: 3500,
+      anneeRef: 2024,
+    },
+    situationFamiliale: 'celibataire',
+    nombreParts: 1,
+    isole: false,
+    children: [],
+    revenusN1Declarant1: {},
+    revenusN1Declarant2: {},
+    projectionNDeclarant1: {},
+    projectionNDeclarant2: {},
+    versementEnvisage: 0,
+    mutualisationConjoints: false,
+  };
+}
+
+function makeHookReturn(step: number) {
+  return {
+    state: makeHookState(step),
+    result: step >= 3
+      ? {
+        situationFiscale: {
+          tmi: 0.3,
+          irEstime: 1000,
+          revenuImposableD1: 20000,
+          revenuImposableD2: 0,
+        },
+        plafond163Q: {
+          declarant1: { disponibleRestant: 6000 },
+          declarant2: undefined,
+        },
+      }
+      : null,
+    baseResult: null,
+    visibleSteps: [1, 2, 3, 5],
+    setMode: vi.fn(),
+    setHistoricalBasis: vi.fn(),
+    setNeedsCurrentYearEstimate: vi.fn(),
+    updateAvisIr: vi.fn(),
+    updateSituation: vi.fn(),
+    updateDeclarant: vi.fn(),
+    addChild: vi.fn(),
+    updateChildMode: vi.fn(),
+    removeChild: vi.fn(),
+    setVersementEnvisage: vi.fn(),
+    nextStep: vi.fn(),
+    prevStep: vi.fn(),
+    goToStep: vi.fn(),
+    reset: vi.fn(),
+    canGoNext: true,
+    isCouple: false,
+  };
+}
+
 describe('PerPotentielSimulator', () => {
   beforeEach(() => {
-    mockUsePerPotentiel.mockReturnValue({
-      state: {
-        step: 2,
-        mode: 'versement-n',
-        historicalBasis: 'previous-avis-plus-n1',
-        needsCurrentYearEstimate: false,
-        avisIr: {
-          nonUtiliseAnnee1: 2000,
-          nonUtiliseAnnee2: 3000,
-          nonUtiliseAnnee3: 1500,
-          plafondCalcule: 4500,
-          anneeRef: 2024,
-        },
-        avisIr2: {
-          nonUtiliseAnnee1: 1000,
-          nonUtiliseAnnee2: 2000,
-          nonUtiliseAnnee3: 500,
-          plafondCalcule: 3500,
-          anneeRef: 2024,
-        },
-        situationFamiliale: 'celibataire',
-        nombreParts: 1,
-        isole: false,
-        revenusN1Declarant1: {},
-        revenusN1Declarant2: {},
-        projectionNDeclarant1: {},
-        projectionNDeclarant2: {},
-        versementEnvisage: 0,
-        mutualisationConjoints: false,
-      },
-      result: null,
-      baseResult: null,
-      visibleSteps: [1, 2, 3, 5],
-      setMode: vi.fn(),
-      setHistoricalBasis: vi.fn(),
-      setNeedsCurrentYearEstimate: vi.fn(),
-      updateAvisIr: vi.fn(),
-      updateSituation: vi.fn(),
-      updateDeclarant: vi.fn(),
-      setVersementEnvisage: vi.fn(),
-      nextStep: vi.fn(),
-      prevStep: vi.fn(),
-      goToStep: vi.fn(),
-      reset: vi.fn(),
-      canGoNext: true,
-      isCouple: false,
-    });
+    mockUsePerPotentiel.mockReset();
+    mockUsePerPotentiel.mockReturnValue(makeHookReturn(2));
   });
 
   it('passes declarant totals to the avis step and shows them in the right sidebar', () => {
@@ -152,6 +178,32 @@ describe('PerPotentielSimulator', () => {
     expect(html).toContain('Potentiel 163 quatervicies');
     expect(html).toContain(fmtCurrency(11000));
     expect(html).toContain(fmtCurrency(7000));
+  });
+
+  it('keeps the avis totals visible in the right sidebar on step 3', () => {
+    mockUsePerPotentiel.mockReturnValue(makeHookReturn(3));
+
+    const html = renderToStaticMarkup(<PerPotentielSimulator />);
+
+    expect(html).toContain('Potentiel 163 quatervicies');
+    expect(html).toContain(fmtCurrency(11000));
+    expect(html).toContain(fmtCurrency(7000));
+  });
+
+  it('hides the avis totals once the simulator reaches step 4', () => {
+    mockUsePerPotentiel.mockReturnValue({
+      ...makeHookReturn(3),
+      state: {
+        ...makeHookState(4),
+        historicalBasis: 'current-avis',
+        needsCurrentYearEstimate: true,
+      },
+      visibleSteps: [1, 2, 3, 4, 5],
+    });
+
+    const html = renderToStaticMarkup(<PerPotentielSimulator />);
+
+    expect(html).not.toContain('Potentiel 163 quatervicies');
   });
 
   it('uses the shared title row pattern for stage headers', () => {

--- a/src/features/per/components/potentiel/PerPotentielSimulator.test.tsx
+++ b/src/features/per/components/potentiel/PerPotentielSimulator.test.tsx
@@ -144,7 +144,6 @@ function makeHookReturn(step: number) {
         },
       }
       : null,
-    baseResult: null,
     visibleSteps: [1, 2, 3, 5],
     setMode: vi.fn(),
     setHistoricalBasis: vi.fn(),
@@ -188,6 +187,16 @@ describe('PerPotentielSimulator', () => {
     expect(html).toContain('Potentiel 163 quatervicies');
     expect(html).toContain(fmtCurrency(11000));
     expect(html).toContain(fmtCurrency(7000));
+  });
+
+  it('shows nombre de parts next to the TMI in the live preview', () => {
+    mockUsePerPotentiel.mockReturnValue(makeHookReturn(3));
+
+    const html = renderToStaticMarkup(<PerPotentielSimulator />);
+
+    expect(html).toContain('Nombre de parts');
+    expect(html).toContain('1');
+    expect(html).toContain('TMI');
   });
 
   it('hides the avis totals once the simulator reaches step 4', () => {

--- a/src/features/per/components/potentiel/PerPotentielSimulator.test.tsx
+++ b/src/features/per/components/potentiel/PerPotentielSimulator.test.tsx
@@ -1,0 +1,164 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUsePerPotentiel = vi.fn();
+
+vi.mock('../../../../hooks/useFiscalContext', () => ({
+  useFiscalContext: () => ({
+    fiscalContext: {
+      irCurrentYearLabel: '2026 (revenus 2025)',
+      irPreviousYearLabel: '2025 (revenus 2024)',
+      passHistoryByYear: {},
+      _raw_tax: {},
+      _raw_ps: {},
+    },
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('../../../../settings/ThemeProvider', () => ({
+  useTheme: () => ({
+    pptxColors: {},
+    cabinetLogo: null,
+    logoPlacement: 'left',
+  }),
+}));
+
+vi.mock('../../../../settings/userMode', () => ({
+  useUserMode: () => ({
+    mode: 'expert',
+  }),
+}));
+
+vi.mock('../../hooks/usePerPotentiel', () => ({
+  usePerPotentiel: (...args: unknown[]) => mockUsePerPotentiel(...args),
+}));
+
+vi.mock('../../hooks/usePerPotentielExportHandlers', () => ({
+  usePerPotentielExportHandlers: () => ({
+    exportExcel: vi.fn(),
+    exportPowerPoint: vi.fn(),
+    exportLoading: false,
+  }),
+}));
+
+vi.mock('../../../../components/ExportMenu', () => ({
+  ExportMenu: () => <div>Export menu</div>,
+}));
+
+vi.mock('../../../../components/ModeToggle', () => ({
+  ModeToggle: () => <div>Mode toggle</div>,
+}));
+
+vi.mock('./steps/ModeStep', () => ({
+  default: () => <div>Mode step</div>,
+}));
+
+vi.mock('./steps/AvisIrStep', () => ({
+  default: ({
+    totalDeclarant1,
+    totalDeclarant2,
+  }: {
+    totalDeclarant1: number;
+    totalDeclarant2: number;
+  }) => (
+    <div>
+      Avis step {totalDeclarant1} / {totalDeclarant2}
+    </div>
+  ),
+}));
+
+vi.mock('./steps/SituationFiscaleStep', () => ({
+  default: () => <div>Situation step</div>,
+}));
+
+vi.mock('./steps/SynthesePotentielStep', () => ({
+  default: () => <div>Synthèse step</div>,
+}));
+
+vi.mock('./PerHypotheses', () => ({
+  PerHypotheses: () => <div>Hypothèses</div>,
+}));
+
+vi.mock('./PerSynthesisSidebar', () => ({
+  PerSynthesisSidebar: () => <div>Sidebar finale</div>,
+}));
+
+import PerPotentielSimulator from './PerPotentielSimulator';
+
+const fmtCurrency = (value: number): string =>
+  new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  }).format(value);
+
+describe('PerPotentielSimulator', () => {
+  beforeEach(() => {
+    mockUsePerPotentiel.mockReturnValue({
+      state: {
+        step: 2,
+        mode: 'versement-n',
+        historicalBasis: 'previous-avis-plus-n1',
+        needsCurrentYearEstimate: false,
+        avisIr: {
+          nonUtiliseAnnee1: 2000,
+          nonUtiliseAnnee2: 3000,
+          nonUtiliseAnnee3: 1500,
+          plafondCalcule: 4500,
+          anneeRef: 2024,
+        },
+        avisIr2: {
+          nonUtiliseAnnee1: 1000,
+          nonUtiliseAnnee2: 2000,
+          nonUtiliseAnnee3: 500,
+          plafondCalcule: 3500,
+          anneeRef: 2024,
+        },
+        situationFamiliale: 'celibataire',
+        nombreParts: 1,
+        isole: false,
+        revenusN1Declarant1: {},
+        revenusN1Declarant2: {},
+        projectionNDeclarant1: {},
+        projectionNDeclarant2: {},
+        versementEnvisage: 0,
+        mutualisationConjoints: false,
+      },
+      result: null,
+      baseResult: null,
+      visibleSteps: [1, 2, 3, 5],
+      setMode: vi.fn(),
+      setHistoricalBasis: vi.fn(),
+      setNeedsCurrentYearEstimate: vi.fn(),
+      updateAvisIr: vi.fn(),
+      updateSituation: vi.fn(),
+      updateDeclarant: vi.fn(),
+      setVersementEnvisage: vi.fn(),
+      nextStep: vi.fn(),
+      prevStep: vi.fn(),
+      goToStep: vi.fn(),
+      reset: vi.fn(),
+      canGoNext: true,
+      isCouple: false,
+    });
+  });
+
+  it('passes declarant totals to the avis step and shows them in the right sidebar', () => {
+    const html = renderToStaticMarkup(<PerPotentielSimulator />);
+
+    expect(html).toContain('Avis step 11000 / 7000');
+    expect(html).toContain('Potentiel 163 quatervicies');
+    expect(html).toContain(fmtCurrency(11000));
+    expect(html).toContain(fmtCurrency(7000));
+  });
+
+  it('uses the shared title row pattern for stage headers', () => {
+    const html = renderToStaticMarkup(<PerPotentielSimulator />);
+
+    expect(html).toContain('per-potentiel-stage-header sim-card__header sim-card__header--bleed');
+    expect(html).toContain('class="sim-card__title-row"');
+    expect(html).toContain('Lecture de l&#x27;avis IR 2025');
+  });
+});

--- a/src/features/per/components/potentiel/PerPotentielSimulator.tsx
+++ b/src/features/per/components/potentiel/PerPotentielSimulator.tsx
@@ -18,6 +18,7 @@ import ModeStep from './steps/ModeStep';
 import AvisIrStep from './steps/AvisIrStep';
 import SituationFiscaleStep from './steps/SituationFiscaleStep';
 import SynthesePotentielStep from './steps/SynthesePotentielStep';
+import type { PerAbattementConfig, PerIncomeFilters } from './steps/PerIncomeTable';
 import { PerHypotheses } from './PerHypotheses';
 import { PerSynthesisSidebar } from './PerSynthesisSidebar';
 import '../../styles/index.css';
@@ -49,6 +50,12 @@ const sumAvisIrPlafonds = (
   + (avis?.nonUtiliseAnnee2 ?? 0)
   + (avis?.nonUtiliseAnnee3 ?? 0)
   + (avis?.plafondCalcule ?? 0);
+
+const DEFAULT_INCOME_FILTERS: PerIncomeFilters = {
+  tns: false,
+  pension: false,
+  foncier: false,
+};
 
 
 function getStepMeta(
@@ -100,6 +107,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
   const { pptxColors, cabinetLogo, logoPlacement } = useTheme();
   const { mode } = useUserMode();
   const [localMode, setLocalMode] = useState<UserMode | null>(null);
+  const [incomeFilters, setIncomeFilters] = useState<PerIncomeFilters>(DEFAULT_INCOME_FILTERS);
   const isExpert = (localMode ?? mode) === 'expert';
   const toggleMode = () => setLocalMode(isExpert ? 'simplifie' : 'expert');
   const years = getPerWorkflowYears(fiscalContext);
@@ -126,6 +134,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
   useEffect(() => {
     const off = onResetEvent(({ simId }: { simId?: string }) => {
       if (simId && simId !== 'per-potentiel') return;
+      setIncomeFilters(DEFAULT_INCOME_FILTERS);
       reset();
     });
     return off;
@@ -193,10 +202,21 @@ export default function PerPotentielSimulator(): React.ReactElement {
   const parcoursPills = buildPills();
   const totalAvisIrD1 = sumAvisIrPlafonds(state.avisIr);
   const totalAvisIrD2 = sumAvisIrPlafonds(state.avisIr2);
+  const abat10CfgRoot = fiscalContext._raw_tax?.incomeTax?.abat10 ?? {};
+  const abat10SalCfgPrevious: PerAbattementConfig = abat10CfgRoot.previous ?? {};
+  const abat10SalCfgCurrent: PerAbattementConfig = abat10CfgRoot.current ?? {};
+  const abat10RetCfgPrevious: PerAbattementConfig = abat10CfgRoot.retireesPrevious ?? {};
+  const abat10RetCfgCurrent: PerAbattementConfig = abat10CfgRoot.retireesCurrent ?? {};
 
   const avisBasis = state.mode === 'declaration-n1'
     ? 'previous-avis-plus-n1'
     : state.historicalBasis ?? 'previous-avis-plus-n1';
+  const toggleIncomeFilter = (key: keyof PerIncomeFilters): void => {
+    setIncomeFilters((prev) => ({
+      ...prev,
+      [key]: prev[key] !== true,
+    }));
+  };
 
   return (
     <div className="sim-page per-potentiel-page">
@@ -283,17 +303,20 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   yearLabel={`${years.currentIncomeYear}`}
                   showFoyerCard
                   situationFamiliale={state.situationFamiliale}
-                  nombreParts={state.nombreParts}
                   isole={state.isole}
                   children={state.children}
                   isCouple={isCouple}
                   mutualisationConjoints={state.mutualisationConjoints}
                   declarant1={state.revenusN1Declarant1}
                   declarant2={state.revenusN1Declarant2}
+                  incomeFilters={incomeFilters}
+                  abat10SalCfg={abat10SalCfgPrevious}
+                  abat10RetCfg={abat10RetCfgPrevious}
                   onUpdateSituation={updateSituation}
                   onAddChild={addChild}
                   onUpdateChildMode={updateChildMode}
                   onRemoveChild={removeChild}
+                  onToggleIncomeFilter={toggleIncomeFilter}
                   onUpdateDeclarant={(decl, patch) => updateDeclarant('revenus-n1', decl, patch)}
                 />
               )}
@@ -304,17 +327,20 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   yearLabel={`${years.currentIncomeYear}`}
                   showFoyerCard
                   situationFamiliale={state.situationFamiliale}
-                  nombreParts={state.nombreParts}
                   isole={state.isole}
                   children={state.children}
                   isCouple={isCouple}
                   mutualisationConjoints={state.mutualisationConjoints}
                   declarant1={state.revenusN1Declarant1}
                   declarant2={state.revenusN1Declarant2}
+                  incomeFilters={incomeFilters}
+                  abat10SalCfg={abat10SalCfgPrevious}
+                  abat10RetCfg={abat10RetCfgPrevious}
                   onUpdateSituation={updateSituation}
                   onAddChild={addChild}
                   onUpdateChildMode={updateChildMode}
                   onRemoveChild={removeChild}
+                  onToggleIncomeFilter={toggleIncomeFilter}
                   onUpdateDeclarant={(decl, patch) => updateDeclarant('revenus-n1', decl, patch)}
                 />
               )}
@@ -324,19 +350,21 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   variant="versements-n"
                   yearLabel={`${years.currentTaxYear}`}
                   showFoyerCard
-                  incomeCardsOptional
                   situationFamiliale={state.situationFamiliale}
-                  nombreParts={state.nombreParts}
                   isole={state.isole}
                   children={state.children}
                   isCouple={isCouple}
                   mutualisationConjoints={state.mutualisationConjoints}
                   declarant1={state.projectionNDeclarant1}
                   declarant2={state.projectionNDeclarant2}
+                  incomeFilters={incomeFilters}
+                  abat10SalCfg={abat10SalCfgCurrent}
+                  abat10RetCfg={abat10RetCfgCurrent}
                   onUpdateSituation={updateSituation}
                   onAddChild={addChild}
                   onUpdateChildMode={updateChildMode}
                   onRemoveChild={removeChild}
+                  onToggleIncomeFilter={toggleIncomeFilter}
                   onUpdateDeclarant={(decl, patch) => updateDeclarant('projection-n', decl, patch)}
                 />
               )}
@@ -347,17 +375,20 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   yearLabel={`${years.currentTaxYear}`}
                   showFoyerCard={false}
                   situationFamiliale={state.situationFamiliale}
-                  nombreParts={state.nombreParts}
                   isole={state.isole}
                   children={state.children}
                   isCouple={isCouple}
                   mutualisationConjoints={state.mutualisationConjoints}
                   declarant1={state.projectionNDeclarant1}
                   declarant2={state.projectionNDeclarant2}
+                  incomeFilters={incomeFilters}
+                  abat10SalCfg={abat10SalCfgCurrent}
+                  abat10RetCfg={abat10RetCfgCurrent}
                   onUpdateSituation={updateSituation}
                   onAddChild={addChild}
                   onUpdateChildMode={updateChildMode}
                   onRemoveChild={removeChild}
+                  onToggleIncomeFilter={toggleIncomeFilter}
                   onUpdateDeclarant={(decl, patch) => updateDeclarant('projection-n', decl, patch)}
                 />
               )}
@@ -441,11 +472,19 @@ export default function PerPotentielSimulator(): React.ReactElement {
               </div>
               <div className="sim-divider sim-divider--tight" />
               <div className="per-potentiel-mini-kpis">
-                <div className="per-potentiel-mini-kpi">
-                  <span className="per-potentiel-mini-kpi-label">TMI</span>
-                  <strong className="per-potentiel-mini-kpi-value">
-                    {fmtPercent(result.situationFiscale.tmi)}
-                  </strong>
+                <div className="per-potentiel-mini-kpis-row">
+                  <div className="per-potentiel-mini-kpi">
+                    <span className="per-potentiel-mini-kpi-label">TMI</span>
+                    <strong className="per-potentiel-mini-kpi-value">
+                      {fmtPercent(result.situationFiscale.tmi)}
+                    </strong>
+                  </div>
+                  <div className="per-potentiel-mini-kpi">
+                    <span className="per-potentiel-mini-kpi-label">Nombre de parts</span>
+                    <strong className="per-potentiel-mini-kpi-value">
+                      {state.nombreParts.toLocaleString('fr-FR')}
+                    </strong>
+                  </div>
                 </div>
                 <div className="per-potentiel-mini-kpi">
                   <span className="per-potentiel-mini-kpi-label">IR estimé</span>

--- a/src/features/per/components/potentiel/PerPotentielSimulator.tsx
+++ b/src/features/per/components/potentiel/PerPotentielSimulator.tsx
@@ -37,6 +37,19 @@ const fmtCurrency = (value: number): string =>
 const fmtPercent = (value: number): string =>
   `${(value <= 1 ? value * 100 : value).toFixed(1)} %`;
 
+const sumAvisIrPlafonds = (
+  avis: {
+    nonUtiliseAnnee1?: number;
+    nonUtiliseAnnee2?: number;
+    nonUtiliseAnnee3?: number;
+    plafondCalcule?: number;
+  } | null,
+): number =>
+  (avis?.nonUtiliseAnnee1 ?? 0)
+  + (avis?.nonUtiliseAnnee2 ?? 0)
+  + (avis?.nonUtiliseAnnee3 ?? 0)
+  + (avis?.plafondCalcule ?? 0);
+
 
 function getStepMeta(
   stepId: WizardStep,
@@ -176,6 +189,8 @@ export default function PerPotentielSimulator(): React.ReactElement {
     return [];
   }
   const parcoursPills = buildPills();
+  const totalAvisIrD1 = sumAvisIrPlafonds(state.avisIr);
+  const totalAvisIrD2 = sumAvisIrPlafonds(state.avisIr2);
 
   const avisBasis = state.mode === 'declaration-n1'
     ? 'previous-avis-plus-n1'
@@ -234,9 +249,18 @@ export default function PerPotentielSimulator(): React.ReactElement {
             />
           ) : (
           <div className="premium-card premium-card--guide per-potentiel-stage">
-            <div className="per-potentiel-stage-header sim-card__header--bleed">
-              <h2 className="per-potentiel-stage-title">{activeStep.title}</h2>
+            <div className="per-potentiel-stage-header sim-card__header sim-card__header--bleed">
+              <div className="sim-card__title-row">
+                <div className="sim-card__icon">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                    <polyline points="14 2 14 8 20 8" />
+                  </svg>
+                </div>
+                <h2 className="sim-card__title">{activeStep.title}</h2>
+              </div>
             </div>
+            <div className="sim-divider per-potentiel-stage-divider" />
 
             <div className="per-potentiel-stage-body">
               {state.step === 2 && (
@@ -245,6 +269,8 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   avisIr2={state.avisIr2}
                   basis={avisBasis}
                   years={years}
+                  totalDeclarant1={totalAvisIrD1}
+                  totalDeclarant2={totalAvisIrD2}
                   onUpdate={updateAvisIr}
                 />
               )}
@@ -360,6 +386,27 @@ export default function PerPotentielSimulator(): React.ReactElement {
                         {pill.label}
                       </span>
                     ))}
+                  </div>
+                </div>
+              )}
+              {state.step === 2 && (
+                <div className="per-avis-sidebar-kpis per-potentiel-context-item">
+                  <span className="per-potentiel-context-label per-potentiel-context-label--small">
+                    Potentiel 163 quatervicies
+                  </span>
+                  <div className="per-potentiel-mini-kpis">
+                    <div className="per-potentiel-mini-kpi">
+                      <span className="per-potentiel-mini-kpi-label">Déclarant 1</span>
+                      <strong className="per-potentiel-mini-kpi-value">
+                        {fmtCurrency(totalAvisIrD1)}
+                      </strong>
+                    </div>
+                    <div className="per-potentiel-mini-kpi">
+                      <span className="per-potentiel-mini-kpi-label">Déclarant 2</span>
+                      <strong className="per-potentiel-mini-kpi-value">
+                        {fmtCurrency(totalAvisIrD2)}
+                      </strong>
+                    </div>
                   </div>
                 </div>
               )}

--- a/src/features/per/components/potentiel/PerPotentielSimulator.tsx
+++ b/src/features/per/components/potentiel/PerPotentielSimulator.tsx
@@ -107,7 +107,6 @@ export default function PerPotentielSimulator(): React.ReactElement {
   const {
     state,
     result,
-    baseResult,
     visibleSteps,
     setMode,
     setHistoricalBasis,
@@ -115,6 +114,9 @@ export default function PerPotentielSimulator(): React.ReactElement {
     updateAvisIr,
     updateSituation,
     updateDeclarant,
+    addChild,
+    updateChildMode,
+    removeChild,
     setVersementEnvisage,
     goToStep,
     reset,
@@ -283,12 +285,15 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   situationFamiliale={state.situationFamiliale}
                   nombreParts={state.nombreParts}
                   isole={state.isole}
+                  children={state.children}
                   isCouple={isCouple}
                   mutualisationConjoints={state.mutualisationConjoints}
                   declarant1={state.revenusN1Declarant1}
                   declarant2={state.revenusN1Declarant2}
-                  result={baseResult}
                   onUpdateSituation={updateSituation}
+                  onAddChild={addChild}
+                  onUpdateChildMode={updateChildMode}
+                  onRemoveChild={removeChild}
                   onUpdateDeclarant={(decl, patch) => updateDeclarant('revenus-n1', decl, patch)}
                 />
               )}
@@ -301,12 +306,15 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   situationFamiliale={state.situationFamiliale}
                   nombreParts={state.nombreParts}
                   isole={state.isole}
+                  children={state.children}
                   isCouple={isCouple}
                   mutualisationConjoints={state.mutualisationConjoints}
                   declarant1={state.revenusN1Declarant1}
                   declarant2={state.revenusN1Declarant2}
-                  result={baseResult}
                   onUpdateSituation={updateSituation}
+                  onAddChild={addChild}
+                  onUpdateChildMode={updateChildMode}
+                  onRemoveChild={removeChild}
                   onUpdateDeclarant={(decl, patch) => updateDeclarant('revenus-n1', decl, patch)}
                 />
               )}
@@ -320,12 +328,15 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   situationFamiliale={state.situationFamiliale}
                   nombreParts={state.nombreParts}
                   isole={state.isole}
+                  children={state.children}
                   isCouple={isCouple}
                   mutualisationConjoints={state.mutualisationConjoints}
                   declarant1={state.projectionNDeclarant1}
                   declarant2={state.projectionNDeclarant2}
-                  result={result}
                   onUpdateSituation={updateSituation}
+                  onAddChild={addChild}
+                  onUpdateChildMode={updateChildMode}
+                  onRemoveChild={removeChild}
                   onUpdateDeclarant={(decl, patch) => updateDeclarant('projection-n', decl, patch)}
                 />
               )}
@@ -338,12 +349,15 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   situationFamiliale={state.situationFamiliale}
                   nombreParts={state.nombreParts}
                   isole={state.isole}
+                  children={state.children}
                   isCouple={isCouple}
                   mutualisationConjoints={state.mutualisationConjoints}
                   declarant1={state.projectionNDeclarant1}
                   declarant2={state.projectionNDeclarant2}
-                  result={result}
                   onUpdateSituation={updateSituation}
+                  onAddChild={addChild}
+                  onUpdateChildMode={updateChildMode}
+                  onRemoveChild={removeChild}
                   onUpdateDeclarant={(decl, patch) => updateDeclarant('projection-n', decl, patch)}
                 />
               )}
@@ -389,7 +403,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   </div>
                 </div>
               )}
-              {state.step === 2 && (
+              {(state.step === 2 || state.step === 3) && (
                 <div className="per-avis-sidebar-kpis per-potentiel-context-item">
                   <span className="per-potentiel-context-label per-potentiel-context-label--small">
                     Potentiel 163 quatervicies

--- a/src/features/per/components/potentiel/steps/AvisIrStep.test.tsx
+++ b/src/features/per/components/potentiel/steps/AvisIrStep.test.tsx
@@ -1,0 +1,57 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import AvisIrStep from './AvisIrStep';
+
+const fmtCurrency = (value: number): string =>
+  new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  }).format(value);
+
+describe('AvisIrStep', () => {
+  it('renders a single matrix with declarant totals', () => {
+    const html = renderToStaticMarkup(
+      <AvisIrStep
+        avisIr={{
+          nonUtiliseAnnee1: 2000,
+          nonUtiliseAnnee2: 3000,
+          nonUtiliseAnnee3: 1500,
+          plafondCalcule: 4500,
+          anneeRef: 2024,
+        }}
+        avisIr2={{
+          nonUtiliseAnnee1: 1000,
+          nonUtiliseAnnee2: 2000,
+          nonUtiliseAnnee3: 500,
+          plafondCalcule: 3500,
+          anneeRef: 2024,
+        }}
+        basis="previous-avis-plus-n1"
+        years={{
+          currentTaxLabel: '2026 (revenus 2025)',
+          previousTaxLabel: '2025 (revenus 2024)',
+          currentTaxYear: 2026,
+          currentIncomeYear: 2025,
+          previousTaxYear: 2025,
+          previousIncomeYear: 2024,
+        }}
+        totalDeclarant1={11000}
+        totalDeclarant2={7000}
+        onUpdate={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('per-avis-matrix');
+    expect(html).toContain('per-avis-matrix-head-row');
+    expect(html).not.toContain('per-avis-form-card');
+    expect(html).toContain('Rubrique');
+    expect(html).toContain('Déclarant 1');
+    expect(html).toContain('Déclarant 2');
+    expect(html).toContain('Potentiel 163 quatervicies pour les cotisations versées en 2025');
+    expect(html).toContain(fmtCurrency(11000));
+    expect(html).toContain(fmtCurrency(7000));
+    expect(html).toContain('aria-label="Plafond non utilisé pour les revenus de 2022 - Déclarant 1"');
+    expect(html).toContain('aria-label="Plafond calculé sur les revenus de 2024 - Déclarant 2"');
+  });
+});

--- a/src/features/per/components/potentiel/steps/AvisIrStep.tsx
+++ b/src/features/per/components/potentiel/steps/AvisIrStep.tsx
@@ -5,68 +5,38 @@
 import React from 'react';
 import type { AvisIrPlafonds, PerHistoricalBasis } from '../../../../../engine/per';
 import { getAvisReferenceYears, type PerWorkflowYears } from '../../../utils/perWorkflowYears';
+import { PerAmountInput } from '../PerAmountInput';
 
 interface AvisIrStepProps {
   avisIr: AvisIrPlafonds | null;
   avisIr2: AvisIrPlafonds | null;
   basis: PerHistoricalBasis;
   years: PerWorkflowYears;
+  totalDeclarant1: number;
+  totalDeclarant2: number;
   onUpdate: (_patch: Partial<AvisIrPlafonds>, _decl?: 1 | 2) => void;
 }
 
-function AvisFieldsCard({
-  label,
-  avis,
-  incomeYear,
-  carryForwardYears,
-  onChange,
-}: {
-  label: string;
-  avis: AvisIrPlafonds | null;
-  incomeYear: number;
-  carryForwardYears: [number, number, number];
-  onChange: (_patch: Partial<AvisIrPlafonds>) => void;
-}): React.ReactElement {
-  const values = avis ?? {
+type AvisFieldKey = keyof Pick<
+  AvisIrPlafonds,
+  'nonUtiliseAnnee1' | 'nonUtiliseAnnee2' | 'nonUtiliseAnnee3' | 'plafondCalcule'
+>;
+
+const fmtCurrency = (value: number): string =>
+  new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  }).format(value);
+
+function getAvisValues(avis: AvisIrPlafonds | null, incomeYear: number): AvisIrPlafonds {
+  return avis ?? {
     nonUtiliseAnnee1: 0,
     nonUtiliseAnnee2: 0,
     nonUtiliseAnnee3: 0,
     plafondCalcule: 0,
     anneeRef: incomeYear,
   };
-
-  const rows = [
-    { label: `Plafond non utilisé ${carryForwardYears[0]}`, key: 'nonUtiliseAnnee1' as const },
-    { label: `Plafond non utilisé ${carryForwardYears[1]}`, key: 'nonUtiliseAnnee2' as const },
-    { label: `Plafond non utilisé ${carryForwardYears[2]}`, key: 'nonUtiliseAnnee3' as const },
-    { label: `Plafond calculé sur revenus ${incomeYear}`, key: 'plafondCalcule' as const },
-  ];
-
-  return (
-    <div className="premium-card per-avis-form-card">
-      <div className="per-avis-form-header sim-card__header--bleed">
-        <p className="premium-section-title">Saisie</p>
-        <h4 className="per-avis-form-title">{label}</h4>
-      </div>
-      <div className="sim-divider" />
-
-      <div className="per-avis-row-list">
-        {rows.map((row) => (
-          <label key={row.key} className="per-avis-row">
-            <span className="per-avis-row-label">{row.label}</span>
-            <input
-              type="number"
-              min={0}
-              className="per-input sim-field__control per-avis-row-input"
-              value={values[row.key] || ''}
-              placeholder="0"
-              onChange={(event) => onChange({ [row.key]: Number(event.target.value) || 0, anneeRef: incomeYear })}
-            />
-          </label>
-        ))}
-      </div>
-    </div>
-  );
 }
 
 export default function AvisIrStep({
@@ -74,38 +44,98 @@ export default function AvisIrStep({
   avisIr2,
   basis,
   years,
+  totalDeclarant1,
+  totalDeclarant2,
   onUpdate,
 }: AvisIrStepProps): React.ReactElement {
   const avisContext = getAvisReferenceYears(years, basis);
-  const totalPlafond = (avisIr?.plafondCalcule ?? 0) + (avisIr2?.plafondCalcule ?? 0);
+  const valuesD1 = getAvisValues(avisIr, avisContext.incomeYear);
+  const valuesD2 = getAvisValues(avisIr2, avisContext.incomeYear);
+  const rows: { label: string; key: AvisFieldKey; operator: '+' | '' }[] = [
+    {
+      label: `Plafond non utilisé pour les revenus de ${avisContext.carryForwardYears[0]}`,
+      key: 'nonUtiliseAnnee1',
+      operator: '',
+    },
+    {
+      label: `Plafond non utilisé pour les revenus de ${avisContext.carryForwardYears[1]}`,
+      key: 'nonUtiliseAnnee2',
+      operator: '+',
+    },
+    {
+      label: `Plafond non utilisé pour les revenus de ${avisContext.carryForwardYears[2]}`,
+      key: 'nonUtiliseAnnee3',
+      operator: '+',
+    },
+    {
+      label: `Plafond calculé sur les revenus de ${avisContext.incomeYear}`,
+      key: 'plafondCalcule',
+      operator: '+',
+    },
+  ];
 
   return (
     <div className="per-step per-step--avis">
-      <div className={`per-avis-form-grid per-avis-form-grid--always-two`}>
-        <AvisFieldsCard
-          label="Déclarant 1"
-          avis={avisIr}
-          incomeYear={avisContext.incomeYear}
-          carryForwardYears={avisContext.carryForwardYears}
-          onChange={(patch) => onUpdate(patch, 1)}
-        />
-
-        <AvisFieldsCard
-          label="Déclarant 2"
-          avis={avisIr2}
-          incomeYear={avisContext.incomeYear}
-          carryForwardYears={avisContext.carryForwardYears}
-          onChange={(patch) => onUpdate(patch, 2)}
-        />
+      <div className="per-avis-intro">
+        <p className="premium-section-title">Avis d&apos;impôt</p>
+        <p className="per-avis-copy">
+          Renseignez les montants relevés sur l&apos;avis IR {avisContext.taxYear}. Le potentiel
+          163 quatervicies correspond à l&apos;addition des trois reports non utilisés et du plafond
+          calculé de l&apos;année de référence, pour chaque déclarant.
+        </p>
       </div>
 
-      <div className="per-avis-total-row">
-        <span className="per-avis-total-label">
-          Plafond pour les cotisations versées en {years.currentTaxYear}
-        </span>
-        <span className="per-avis-total-value">
-          {totalPlafond.toLocaleString('fr-FR')} €
-        </span>
+      <div className="per-avis-matrix" role="table" aria-label={`Lecture de l'avis IR ${avisContext.taxYear}`}>
+        <div className="per-avis-matrix-head-row" role="row">
+          <div className="per-avis-matrix-head per-avis-matrix-head--label" role="columnheader">
+            Rubrique
+          </div>
+          <div className="per-avis-matrix-head per-avis-matrix-head--operator" aria-hidden="true" />
+          <div className="per-avis-matrix-head" role="columnheader">Déclarant 1</div>
+          <div className="per-avis-matrix-head" role="columnheader">Déclarant 2</div>
+        </div>
+
+        {rows.map((row) => (
+          <div key={row.key} className="per-avis-matrix-row" role="row">
+            <div className="per-avis-matrix-label" role="rowheader">
+              {row.label}
+            </div>
+            <div className="per-avis-matrix-operator" aria-hidden="true">
+              {row.operator}
+            </div>
+            <div className="per-avis-matrix-cell" data-column-label="Déclarant 1" role="cell">
+              <PerAmountInput
+                value={valuesD1[row.key]}
+                ariaLabel={`${row.label} - Déclarant 1`}
+                className="per-avis-matrix-input"
+                onChange={(value) => onUpdate({ [row.key]: value, anneeRef: avisContext.incomeYear }, 1)}
+              />
+            </div>
+            <div className="per-avis-matrix-cell" data-column-label="Déclarant 2" role="cell">
+              <PerAmountInput
+                value={valuesD2[row.key]}
+                ariaLabel={`${row.label} - Déclarant 2`}
+                className="per-avis-matrix-input"
+                onChange={(value) => onUpdate({ [row.key]: value, anneeRef: avisContext.incomeYear }, 2)}
+              />
+            </div>
+          </div>
+        ))}
+
+        <div className="per-avis-matrix-row per-avis-matrix-row--total" role="row">
+          <div className="per-avis-matrix-label per-avis-matrix-label--total" role="rowheader">
+            Potentiel 163 quatervicies pour les cotisations versées en {avisContext.taxYear}
+          </div>
+          <div className="per-avis-matrix-operator per-avis-matrix-operator--total" aria-hidden="true">
+            =
+          </div>
+          <div className="per-avis-matrix-total" data-column-label="Déclarant 1" role="cell">
+            {fmtCurrency(totalDeclarant1)}
+          </div>
+          <div className="per-avis-matrix-total" data-column-label="Déclarant 2" role="cell">
+            {fmtCurrency(totalDeclarant2)}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/features/per/components/potentiel/steps/ModeStep.tsx
+++ b/src/features/per/components/potentiel/steps/ModeStep.tsx
@@ -56,20 +56,20 @@ export default function ModeStep({
         </div>
         <div className="sim-divider" />
 
-      <div className="per-mode-grid">
-        {modes.map((item) => (
-          <button
-            key={item.id}
-            type="button"
-            className={`per-mode-card ${mode === item.id ? 'per-mode-card--selected' : ''}`}
-            onClick={() => onSelectMode(item.id)}
-          >
-            <span className="per-mode-card-marker">{item.marker}</span>
-            <h4 className="per-mode-card-title">{item.title}</h4>
-            <p className="per-mode-card-desc">{item.desc}</p>
-          </button>
-        ))}
-      </div>
+        <div className="per-mode-grid">
+          {modes.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              className={`per-mode-card ${mode === item.id ? 'per-mode-card--selected' : ''}`}
+              onClick={() => onSelectMode(item.id)}
+            >
+              <span className="per-mode-card-marker">{item.marker}</span>
+              <h4 className="per-mode-card-title">{item.title}</h4>
+              <p className="per-mode-card-desc">{item.desc}</p>
+            </button>
+          ))}
+        </div>
       </div>
 
       {mode !== null && (
@@ -138,9 +138,9 @@ export default function ModeStep({
                 </div>
                 {needsCurrentYearEstimate && (
                   <p className="per-mode-toggle-hint">
-                    Activez l&apos;estimation {years.currentTaxYear} si vous devez intégrer des revenus ou
-                    versements de l&apos;année en cours pour Madelin, PERCO, PEROB ou art. 83. Il vous faudra
-                    estimer les revenus et les versements {years.currentTaxYear}.
+                    L&apos;estimation {years.currentTaxYear} est activée. Vous renseignerez les revenus
+                    et versements de l&apos;année en cours (Madelin, PERCO, PEROB, art. 83) à l&apos;étape
+                    suivante.
                   </p>
                 )}
               </div>

--- a/src/features/per/components/potentiel/steps/PerIncomeTable.tsx
+++ b/src/features/per/components/potentiel/steps/PerIncomeTable.tsx
@@ -1,0 +1,407 @@
+import React from 'react';
+import { computeAbattement10 } from '../../../../../engine/ir/abattement10';
+import type { DeclarantRevenus } from '../../../../../engine/per';
+import { formatInteger } from '../../../../../utils/formatNumber';
+import { PerAmountInput } from '../PerAmountInput';
+
+export type PerIncomeFilters = {
+  tns: boolean;
+  pension: boolean;
+  foncier: boolean;
+};
+
+export interface PerAbattementConfig {
+  plafond?: number | string | null;
+  plancher?: number | string | null;
+}
+
+function formatReadonlyAmount(value: number): string {
+  return formatInteger(Math.max(0, Math.round(value || 0)));
+}
+
+function formatReadonlyMoney(value: number): string {
+  return `${formatReadonlyAmount(value)} €`;
+}
+
+function SectionIcon({ kind }: { kind: 'foyer' | 'revenus' | 'versements' }): React.ReactElement {
+  if (kind === 'foyer') {
+    return (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+        <circle cx="9" cy="7" r="4" />
+        <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+        <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+      </svg>
+    );
+  }
+
+  if (kind === 'revenus') {
+    return (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <rect x="3" y="3" width="18" height="18" rx="2" />
+        <line x1="3" y1="9" x2="21" y2="9" />
+        <line x1="3" y1="15" x2="21" y2="15" />
+        <line x1="12" y1="3" x2="12" y2="21" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M3 7h18" />
+      <path d="M6 11h12" />
+      <path d="M8 15h8" />
+      <path d="M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Z" />
+    </svg>
+  );
+}
+
+export function SectionHeader({
+  title,
+  subtitle,
+  icon,
+  eyebrow,
+  actions,
+}: {
+  title: string;
+  subtitle?: string;
+  icon: 'foyer' | 'revenus' | 'versements';
+  eyebrow?: string;
+  actions?: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <>
+      <div className="sim-card__header sim-card__header--bleed per-section-header">
+        <div className="per-section-header-row">
+          <div className="sim-card__title-row">
+            <div className="sim-card__icon">
+              <SectionIcon kind={icon} />
+            </div>
+            <div className="per-section-title-block">
+              {eyebrow ? <p className="premium-section-title">{eyebrow}</p> : null}
+              <h3 className="sim-card__title">{title}</h3>
+            </div>
+          </div>
+          {actions ? <div className="per-section-header-actions">{actions}</div> : null}
+        </div>
+        {subtitle ? <p className="per-section-subtitle">{subtitle}</p> : null}
+      </div>
+      <div className="sim-divider" />
+    </>
+  );
+}
+
+function ReadonlyAmountInput({
+  value,
+  ariaLabel,
+}: {
+  value: number;
+  ariaLabel: string;
+}): React.ReactElement {
+  return (
+    <input
+      type="text"
+      readOnly
+      aria-label={ariaLabel}
+      value={formatReadonlyAmount(value)}
+      className="per-input sim-field__control per-income-table-input per-income-table-input--readonly"
+    />
+  );
+}
+
+function DividerRow({ isCouple }: { isCouple: boolean }): React.ReactElement {
+  return (
+    <tr className="per-divider-row">
+      <td colSpan={isCouple ? 3 : 2}>
+        <div className="per-divider-row__inner" />
+      </td>
+    </tr>
+  );
+}
+
+export function PerIncomeTable({
+  isCouple,
+  declarant1,
+  declarant2,
+  incomeFilters,
+  abat10SalCfg,
+  abat10RetCfg,
+  onToggleIncomeFilter,
+  onUpdateDeclarant,
+}: {
+  isCouple: boolean;
+  declarant1: DeclarantRevenus;
+  declarant2: DeclarantRevenus;
+  incomeFilters: PerIncomeFilters;
+  abat10SalCfg: PerAbattementConfig;
+  abat10RetCfg: PerAbattementConfig;
+  onToggleIncomeFilter: (_key: keyof PerIncomeFilters) => void;
+  onUpdateDeclarant: (_decl: 1 | 2, _patch: Partial<DeclarantRevenus>) => void;
+}): React.ReactElement {
+  const showTnsRows = incomeFilters.tns === true;
+  const showPensionRows = incomeFilters.pension === true;
+  const showFoncierRow = incomeFilters.foncier === true;
+
+  const abat10SalD1 = computeAbattement10(
+    (declarant1.salaires || 0) + (declarant1.art62 || 0),
+    abat10SalCfg,
+  );
+  const abat10SalD2 = computeAbattement10(
+    (declarant2.salaires || 0) + (declarant2.art62 || 0),
+    abat10SalCfg,
+  );
+  const abat10PensionsFoyer = computeAbattement10(
+    (declarant1.retraites || 0) + (isCouple ? (declarant2.retraites || 0) : 0),
+    abat10RetCfg,
+  );
+
+  return (
+    <div className="premium-card premium-card--guide sim-card--guide per-income-table-card">
+      <SectionHeader
+        title="Revenus imposables"
+        subtitle="Renseignez vos sources de revenus par catégorie pour affiner le calcul"
+        icon="revenus"
+        actions={(
+          <div className="per-income-filters" role="group" aria-label="Filtres des lignes de revenus imposables">
+            <button
+              type="button"
+              className={`per-income-filter-btn${showTnsRows ? ' is-active' : ''}`}
+              onClick={() => onToggleIncomeFilter('tns')}
+              aria-pressed={showTnsRows}
+              data-testid="per-filter-tns"
+            >
+              TNS
+            </button>
+            <button
+              type="button"
+              className={`per-income-filter-btn${showPensionRows ? ' is-active' : ''}`}
+              onClick={() => onToggleIncomeFilter('pension')}
+              aria-pressed={showPensionRows}
+              data-testid="per-filter-pension"
+            >
+              Pension
+            </button>
+            <button
+              type="button"
+              className={`per-income-filter-btn${showFoncierRow ? ' is-active' : ''}`}
+              onClick={() => onToggleIncomeFilter('foncier')}
+              aria-pressed={showFoncierRow}
+              data-testid="per-filter-foncier"
+            >
+              Foncier
+            </button>
+          </div>
+        )}
+      />
+
+      <div className="per-income-table-wrap">
+        <table className={`per-income-table${isCouple ? '' : ' per-income-table--single'}`} aria-label="Revenus imposables">
+          <colgroup>
+            <col style={{ width: '40%' }} />
+            <col style={{ width: '30%' }} />
+            <col style={{ width: '30%' }} />
+          </colgroup>
+          <thead>
+            <tr>
+              <th aria-label="Catégorie"></th>
+              <th>Déclarant 1</th>
+              <th>Déclarant 2</th>
+            </tr>
+          </thead>
+          <tbody>
+            <DividerRow isCouple={isCouple} />
+            <tr>
+              <td>Traitements et salaires</td>
+              <td data-column-label="Déclarant 1">
+                <PerAmountInput
+                  value={declarant1.salaires}
+                  ariaLabel="Traitements et salaires déclarant 1"
+                  className="per-income-table-input"
+                  onChange={(value) => onUpdateDeclarant(1, { salaires: value })}
+                />
+              </td>
+              <td data-column-label="Déclarant 2">
+                <PerAmountInput
+                  value={declarant2.salaires}
+                  ariaLabel="Traitements et salaires déclarant 2"
+                  className="per-income-table-input"
+                  onChange={(value) => onUpdateDeclarant(2, { salaires: value })}
+                />
+              </td>
+            </tr>
+            {showTnsRows && (
+              <tr>
+                <td>Revenus des associés / gérants</td>
+                <td data-column-label="Déclarant 1">
+                  <PerAmountInput
+                    value={declarant1.art62}
+                    ariaLabel="Revenus des associés ou gérants déclarant 1"
+                    className="per-income-table-input"
+                    onChange={(value) => onUpdateDeclarant(1, { art62: value })}
+                  />
+                </td>
+                <td data-column-label="Déclarant 2">
+                  <PerAmountInput
+                    value={declarant2.art62}
+                    ariaLabel="Revenus des associés ou gérants déclarant 2"
+                    className="per-income-table-input"
+                    onChange={(value) => onUpdateDeclarant(2, { art62: value })}
+                  />
+                </td>
+              </tr>
+            )}
+            <tr className="per-income-table-row-title">
+              <td>Frais réels ou abattement 10 %</td>
+              <td data-column-label="Déclarant 1">
+                <div className="per-income-real-cell">
+                  <select
+                    className="per-select sim-field__control per-income-real-select"
+                    value={declarant1.fraisReels ? 'reels' : 'abat10'}
+                    onChange={(event) => onUpdateDeclarant(1, { fraisReels: event.target.value === 'reels' })}
+                  >
+                    <option value="reels">FR</option>
+                    <option value="abat10">10%</option>
+                  </select>
+                  {declarant1.fraisReels ? (
+                    <PerAmountInput
+                      value={declarant1.fraisReelsMontant}
+                      ariaLabel="Montant des frais réels déclarant 1"
+                      className="per-income-table-input"
+                      onChange={(value) => onUpdateDeclarant(1, { fraisReelsMontant: value })}
+                    />
+                  ) : (
+                    <ReadonlyAmountInput
+                      value={abat10SalD1}
+                      ariaLabel="Abattement 10 % déclarant 1"
+                    />
+                  )}
+                </div>
+              </td>
+              <td data-column-label="Déclarant 2">
+                <div className="per-income-real-cell">
+                  <select
+                    className="per-select sim-field__control per-income-real-select"
+                    value={declarant2.fraisReels ? 'reels' : 'abat10'}
+                    onChange={(event) => onUpdateDeclarant(2, { fraisReels: event.target.value === 'reels' })}
+                  >
+                    <option value="reels">FR</option>
+                    <option value="abat10">10%</option>
+                  </select>
+                  {declarant2.fraisReels ? (
+                    <PerAmountInput
+                      value={declarant2.fraisReelsMontant}
+                      ariaLabel="Montant des frais réels déclarant 2"
+                      className="per-income-table-input"
+                      onChange={(value) => onUpdateDeclarant(2, { fraisReelsMontant: value })}
+                    />
+                  ) : (
+                    <ReadonlyAmountInput
+                      value={abat10SalD2}
+                      ariaLabel="Abattement 10 % déclarant 2"
+                    />
+                  )}
+                </div>
+              </td>
+            </tr>
+            <DividerRow isCouple={isCouple} />
+            {showTnsRows && (
+              <tr>
+                <td>BIC / BNC / BA imposables</td>
+                <td data-column-label="Déclarant 1">
+                  <PerAmountInput
+                    value={declarant1.bic}
+                    ariaLabel="BIC BNC BA imposables déclarant 1"
+                    className="per-income-table-input"
+                    onChange={(value) => onUpdateDeclarant(1, { bic: value })}
+                  />
+                </td>
+                <td data-column-label="Déclarant 2">
+                  <PerAmountInput
+                    value={declarant2.bic}
+                    ariaLabel="BIC BNC BA imposables déclarant 2"
+                    className="per-income-table-input"
+                    onChange={(value) => onUpdateDeclarant(2, { bic: value })}
+                  />
+                </td>
+              </tr>
+            )}
+            <tr>
+              <td>Autres revenus imposables</td>
+              <td data-column-label="Déclarant 1">
+                <PerAmountInput
+                  value={declarant1.autresRevenus}
+                  ariaLabel="Autres revenus imposables déclarant 1"
+                  className="per-income-table-input"
+                  onChange={(value) => onUpdateDeclarant(1, { autresRevenus: value })}
+                />
+              </td>
+              <td data-column-label="Déclarant 2">
+                <PerAmountInput
+                  value={declarant2.autresRevenus}
+                  ariaLabel="Autres revenus imposables déclarant 2"
+                  className="per-income-table-input"
+                  onChange={(value) => onUpdateDeclarant(2, { autresRevenus: value })}
+                />
+              </td>
+            </tr>
+            {(showPensionRows || showFoncierRow) && <DividerRow isCouple={isCouple} />}
+
+            {showPensionRows && (
+              <>
+                <tr>
+                  <td>Pensions, retraites et rentes</td>
+                  <td data-column-label="Déclarant 1">
+                    <PerAmountInput
+                      value={declarant1.retraites}
+                      ariaLabel="Pensions retraites et rentes déclarant 1"
+                      className="per-income-table-input"
+                      onChange={(value) => onUpdateDeclarant(1, { retraites: value })}
+                    />
+                  </td>
+                  <td data-column-label="Déclarant 2">
+                    <PerAmountInput
+                      value={declarant2.retraites}
+                      ariaLabel="Pensions retraites et rentes déclarant 2"
+                      className="per-income-table-input"
+                      onChange={(value) => onUpdateDeclarant(2, { retraites: value })}
+                    />
+                  </td>
+                </tr>
+                <tr className="per-income-table-row-title">
+                  <td>Abattement 10 % pensions (foyer)</td>
+                  <td colSpan={2} className="per-income-table-value-cell per-income-table-value-cell--center">
+                    {formatReadonlyMoney(abat10PensionsFoyer)}
+                  </td>
+                </tr>
+              </>
+            )}
+
+            {showPensionRows && showFoncierRow && <DividerRow isCouple={isCouple} />}
+
+            {showFoncierRow && (
+              <tr>
+                <td>Revenus fonciers nets</td>
+                <td data-column-label="Déclarant 1">
+                  <PerAmountInput
+                    value={declarant1.fonciersNets}
+                    ariaLabel="Revenus fonciers nets déclarant 1"
+                    className="per-income-table-input"
+                    onChange={(value) => onUpdateDeclarant(1, { fonciersNets: value })}
+                  />
+                </td>
+                <td data-column-label="Déclarant 2">
+                  <PerAmountInput
+                    value={declarant2.fonciersNets}
+                    ariaLabel="Revenus fonciers nets déclarant 2"
+                    className="per-income-table-input"
+                    onChange={(value) => onUpdateDeclarant(2, { fonciersNets: value })}
+                  />
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/features/per/components/potentiel/steps/PerIncomeTable.tsx
+++ b/src/features/per/components/potentiel/steps/PerIncomeTable.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { SimFieldShell } from '@/components/ui/sim';
+import { SimSelect } from '@/components/ui/sim/SimSelect';
 import { computeAbattement10 } from '../../../../../engine/ir/abattement10';
 import type { DeclarantRevenus } from '../../../../../engine/per';
 import { formatInteger } from '../../../../../utils/formatNumber';
@@ -99,13 +101,38 @@ function ReadonlyAmountInput({
   ariaLabel: string;
 }): React.ReactElement {
   return (
-    <input
-      type="text"
-      readOnly
-      aria-label={ariaLabel}
-      value={formatReadonlyAmount(value)}
-      className="per-input sim-field__control per-income-table-input per-income-table-input--readonly"
-    />
+    <SimFieldShell className="per-table-input" rowClassName="per-table-input__row">
+      <input
+        type="text"
+        readOnly
+        aria-label={ariaLabel}
+        value={formatReadonlyAmount(value)}
+        className="sim-field__control per-table-input__control per-table-input__control--readonly"
+      />
+      <span className="per-table-input__unit sim-field__unit" aria-hidden="true">€</span>
+    </SimFieldShell>
+  );
+}
+
+function PerTableAmountInput({
+  value,
+  ariaLabel,
+  onChange,
+}: {
+  value: number;
+  ariaLabel: string;
+  onChange: (_value: number) => void;
+}): React.ReactElement {
+  return (
+    <SimFieldShell className="per-table-input" rowClassName="per-table-input__row">
+      <PerAmountInput
+        value={value}
+        ariaLabel={ariaLabel}
+        className="per-table-input__control"
+        onChange={onChange}
+      />
+      <span className="per-table-input__unit sim-field__unit" aria-hidden="true">€</span>
+    </SimFieldShell>
   );
 }
 
@@ -213,18 +240,16 @@ export function PerIncomeTable({
             <tr>
               <td>Traitements et salaires</td>
               <td data-column-label="Déclarant 1">
-                <PerAmountInput
+                <PerTableAmountInput
                   value={declarant1.salaires}
                   ariaLabel="Traitements et salaires déclarant 1"
-                  className="per-income-table-input"
                   onChange={(value) => onUpdateDeclarant(1, { salaires: value })}
                 />
               </td>
               <td data-column-label="Déclarant 2">
-                <PerAmountInput
+                <PerTableAmountInput
                   value={declarant2.salaires}
                   ariaLabel="Traitements et salaires déclarant 2"
-                  className="per-income-table-input"
                   onChange={(value) => onUpdateDeclarant(2, { salaires: value })}
                 />
               </td>
@@ -233,18 +258,16 @@ export function PerIncomeTable({
               <tr>
                 <td>Revenus des associés / gérants</td>
                 <td data-column-label="Déclarant 1">
-                  <PerAmountInput
+                  <PerTableAmountInput
                     value={declarant1.art62}
                     ariaLabel="Revenus des associés ou gérants déclarant 1"
-                    className="per-income-table-input"
                     onChange={(value) => onUpdateDeclarant(1, { art62: value })}
                   />
                 </td>
                 <td data-column-label="Déclarant 2">
-                  <PerAmountInput
+                  <PerTableAmountInput
                     value={declarant2.art62}
                     ariaLabel="Revenus des associés ou gérants déclarant 2"
-                    className="per-income-table-input"
                     onChange={(value) => onUpdateDeclarant(2, { art62: value })}
                   />
                 </td>
@@ -254,19 +277,19 @@ export function PerIncomeTable({
               <td>Frais réels ou abattement 10 %</td>
               <td data-column-label="Déclarant 1">
                 <div className="per-income-real-cell">
-                  <select
-                    className="per-select sim-field__control per-income-real-select"
+                  <SimSelect
                     value={declarant1.fraisReels ? 'reels' : 'abat10'}
-                    onChange={(event) => onUpdateDeclarant(1, { fraisReels: event.target.value === 'reels' })}
-                  >
-                    <option value="reels">FR</option>
-                    <option value="abat10">10%</option>
-                  </select>
+                    onChange={(value) => onUpdateDeclarant(1, { fraisReels: value === 'reels' })}
+                    options={[
+                      { value: 'reels', label: 'FR' },
+                      { value: 'abat10', label: '10%' },
+                    ]}
+                    className="per-income-real-select"
+                  />
                   {declarant1.fraisReels ? (
-                    <PerAmountInput
+                    <PerTableAmountInput
                       value={declarant1.fraisReelsMontant}
                       ariaLabel="Montant des frais réels déclarant 1"
-                      className="per-income-table-input"
                       onChange={(value) => onUpdateDeclarant(1, { fraisReelsMontant: value })}
                     />
                   ) : (
@@ -279,19 +302,19 @@ export function PerIncomeTable({
               </td>
               <td data-column-label="Déclarant 2">
                 <div className="per-income-real-cell">
-                  <select
-                    className="per-select sim-field__control per-income-real-select"
+                  <SimSelect
                     value={declarant2.fraisReels ? 'reels' : 'abat10'}
-                    onChange={(event) => onUpdateDeclarant(2, { fraisReels: event.target.value === 'reels' })}
-                  >
-                    <option value="reels">FR</option>
-                    <option value="abat10">10%</option>
-                  </select>
+                    onChange={(value) => onUpdateDeclarant(2, { fraisReels: value === 'reels' })}
+                    options={[
+                      { value: 'reels', label: 'FR' },
+                      { value: 'abat10', label: '10%' },
+                    ]}
+                    className="per-income-real-select"
+                  />
                   {declarant2.fraisReels ? (
-                    <PerAmountInput
+                    <PerTableAmountInput
                       value={declarant2.fraisReelsMontant}
                       ariaLabel="Montant des frais réels déclarant 2"
-                      className="per-income-table-input"
                       onChange={(value) => onUpdateDeclarant(2, { fraisReelsMontant: value })}
                     />
                   ) : (
@@ -308,18 +331,16 @@ export function PerIncomeTable({
               <tr>
                 <td>BIC / BNC / BA imposables</td>
                 <td data-column-label="Déclarant 1">
-                  <PerAmountInput
+                  <PerTableAmountInput
                     value={declarant1.bic}
                     ariaLabel="BIC BNC BA imposables déclarant 1"
-                    className="per-income-table-input"
                     onChange={(value) => onUpdateDeclarant(1, { bic: value })}
                   />
                 </td>
                 <td data-column-label="Déclarant 2">
-                  <PerAmountInput
+                  <PerTableAmountInput
                     value={declarant2.bic}
                     ariaLabel="BIC BNC BA imposables déclarant 2"
-                    className="per-income-table-input"
                     onChange={(value) => onUpdateDeclarant(2, { bic: value })}
                   />
                 </td>
@@ -328,18 +349,16 @@ export function PerIncomeTable({
             <tr>
               <td>Autres revenus imposables</td>
               <td data-column-label="Déclarant 1">
-                <PerAmountInput
+                <PerTableAmountInput
                   value={declarant1.autresRevenus}
                   ariaLabel="Autres revenus imposables déclarant 1"
-                  className="per-income-table-input"
                   onChange={(value) => onUpdateDeclarant(1, { autresRevenus: value })}
                 />
               </td>
               <td data-column-label="Déclarant 2">
-                <PerAmountInput
+                <PerTableAmountInput
                   value={declarant2.autresRevenus}
                   ariaLabel="Autres revenus imposables déclarant 2"
-                  className="per-income-table-input"
                   onChange={(value) => onUpdateDeclarant(2, { autresRevenus: value })}
                 />
               </td>
@@ -351,18 +370,16 @@ export function PerIncomeTable({
                 <tr>
                   <td>Pensions, retraites et rentes</td>
                   <td data-column-label="Déclarant 1">
-                    <PerAmountInput
+                    <PerTableAmountInput
                       value={declarant1.retraites}
                       ariaLabel="Pensions retraites et rentes déclarant 1"
-                      className="per-income-table-input"
                       onChange={(value) => onUpdateDeclarant(1, { retraites: value })}
                     />
                   </td>
                   <td data-column-label="Déclarant 2">
-                    <PerAmountInput
+                    <PerTableAmountInput
                       value={declarant2.retraites}
                       ariaLabel="Pensions retraites et rentes déclarant 2"
-                      className="per-income-table-input"
                       onChange={(value) => onUpdateDeclarant(2, { retraites: value })}
                     />
                   </td>
@@ -382,18 +399,16 @@ export function PerIncomeTable({
               <tr>
                 <td>Revenus fonciers nets</td>
                 <td data-column-label="Déclarant 1">
-                  <PerAmountInput
+                  <PerTableAmountInput
                     value={declarant1.fonciersNets}
                     ariaLabel="Revenus fonciers nets déclarant 1"
-                    className="per-income-table-input"
                     onChange={(value) => onUpdateDeclarant(1, { fonciersNets: value })}
                   />
                 </td>
                 <td data-column-label="Déclarant 2">
-                  <PerAmountInput
+                  <PerTableAmountInput
                     value={declarant2.fonciersNets}
                     ariaLabel="Revenus fonciers nets déclarant 2"
-                    className="per-income-table-input"
                     onChange={(value) => onUpdateDeclarant(2, { fonciersNets: value })}
                   />
                 </td>

--- a/src/features/per/components/potentiel/steps/SituationFiscaleStep.test.tsx
+++ b/src/features/per/components/potentiel/steps/SituationFiscaleStep.test.tsx
@@ -96,6 +96,7 @@ describe('SituationFiscaleStep', () => {
       <SituationFiscaleStep
         showFoyerCard={false}
         {...baseProps}
+        incomeFilters={{ tns: true, pension: false, foncier: false }}
       />,
     );
 

--- a/src/features/per/components/potentiel/steps/SituationFiscaleStep.test.tsx
+++ b/src/features/per/components/potentiel/steps/SituationFiscaleStep.test.tsx
@@ -1,0 +1,79 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import SituationFiscaleStep from './SituationFiscaleStep';
+
+const baseDeclarant = {
+  salaires: 45000,
+  fraisReels: false,
+  fraisReelsMontant: 0,
+  art62: 0,
+  bic: 0,
+  retraites: 0,
+  fonciersNets: 0,
+  autresRevenus: 0,
+  cotisationsPer163Q: 2000,
+  cotisationsPerp: 0,
+  cotisationsArt83: 1200,
+  cotisationsMadelin154bis: 0,
+  cotisationsMadelinRetraite: 3000,
+  abondementPerco: 500,
+  cotisationsPrevo: 0,
+};
+
+describe('SituationFiscaleStep', () => {
+  it('renders foyer, revenus and versements in order without local fiscal preview', () => {
+    const html = renderToStaticMarkup(
+      <SituationFiscaleStep
+        variant="revenus-n1"
+        yearLabel="2025"
+        showFoyerCard
+        situationFamiliale="celibataire"
+        nombreParts={1.5}
+        isole
+        children={[{ id: 1, mode: 'charge' }]}
+        isCouple={false}
+        mutualisationConjoints={false}
+        declarant1={baseDeclarant}
+        declarant2={baseDeclarant}
+        onUpdateSituation={vi.fn()}
+        onAddChild={vi.fn()}
+        onUpdateChildMode={vi.fn()}
+        onRemoveChild={vi.fn()}
+        onUpdateDeclarant={vi.fn()}
+      />,
+    );
+
+    expect(html).not.toContain('Aperçu fiscal');
+    expect(html.indexOf('Situation familiale')).toBeLessThan(html.indexOf('Revenus imposables'));
+    expect(html.indexOf('Revenus imposables')).toBeLessThan(html.indexOf('Montants 2025 par déclarant'));
+    expect(html).toContain('Nombre de parts calculé');
+    expect(html).toContain('Ajouter un enfant');
+  });
+
+  it('uses the updated contribution notes without adding unsupported 2042 boxes', () => {
+    const html = renderToStaticMarkup(
+      <SituationFiscaleStep
+        variant="revenus-n1"
+        yearLabel="2025"
+        showFoyerCard={false}
+        situationFamiliale="celibataire"
+        nombreParts={1}
+        isole={false}
+        children={[]}
+        isCouple={false}
+        mutualisationConjoints={false}
+        declarant1={baseDeclarant}
+        declarant2={baseDeclarant}
+        onUpdateSituation={vi.fn()}
+        onAddChild={vi.fn()}
+        onUpdateChildMode={vi.fn()}
+        onRemoveChild={vi.fn()}
+        onUpdateDeclarant={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('2042 : 6OS / 6OT');
+    expect(html).toContain('contrat retraite, distinct du PER 154 bis');
+    expect(html).toContain('employeur, réduit le plafond 163Q');
+  });
+});

--- a/src/features/per/components/potentiel/steps/SituationFiscaleStep.test.tsx
+++ b/src/features/per/components/potentiel/steps/SituationFiscaleStep.test.tsx
@@ -20,55 +20,82 @@ const baseDeclarant = {
   cotisationsPrevo: 0,
 };
 
+const baseProps = {
+  variant: 'revenus-n1' as const,
+  yearLabel: '2025',
+  situationFamiliale: 'celibataire' as const,
+  isole: true,
+  children: [{ id: 1, mode: 'charge' as const }],
+  isCouple: false,
+  mutualisationConjoints: false,
+  declarant1: baseDeclarant,
+  declarant2: baseDeclarant,
+  incomeFilters: { tns: false, pension: false, foncier: false },
+  abat10SalCfg: { plafond: 14522, plancher: 495 },
+  abat10RetCfg: { plafond: 4399, plancher: 450 },
+  onUpdateSituation: vi.fn(),
+  onAddChild: vi.fn(),
+  onUpdateChildMode: vi.fn(),
+  onRemoveChild: vi.fn(),
+  onToggleIncomeFilter: vi.fn(),
+  onUpdateDeclarant: vi.fn(),
+};
+
 describe('SituationFiscaleStep', () => {
-  it('renders foyer, revenus and versements in order without local fiscal preview', () => {
+  it('renders foyer, revenus and versements in order without number of parts in the foyer', () => {
     const html = renderToStaticMarkup(
       <SituationFiscaleStep
-        variant="revenus-n1"
-        yearLabel="2025"
         showFoyerCard
-        situationFamiliale="celibataire"
-        nombreParts={1.5}
-        isole
-        children={[{ id: 1, mode: 'charge' }]}
-        isCouple={false}
-        mutualisationConjoints={false}
-        declarant1={baseDeclarant}
-        declarant2={baseDeclarant}
-        onUpdateSituation={vi.fn()}
-        onAddChild={vi.fn()}
-        onUpdateChildMode={vi.fn()}
-        onRemoveChild={vi.fn()}
-        onUpdateDeclarant={vi.fn()}
+        {...baseProps}
       />,
     );
 
-    expect(html).not.toContain('Aperçu fiscal');
+    expect(html).not.toContain('Nombre de parts calculÃ©');
+    expect(html).not.toContain('AperÃ§u fiscal');
     expect(html.indexOf('Situation familiale')).toBeLessThan(html.indexOf('Revenus imposables'));
-    expect(html.indexOf('Revenus imposables')).toBeLessThan(html.indexOf('Montants 2025 par déclarant'));
-    expect(html).toContain('Nombre de parts calculé');
+    expect(html.indexOf('Revenus imposables')).toBeLessThan(html.indexOf('Versements retraite'));
     expect(html).toContain('Ajouter un enfant');
+    expect(html).not.toContain('Mutualisation des plafonds (case 6QR)');
+  });
+
+  it('renders mutualisation des plafonds inside the versements block for couples', () => {
+    const html = renderToStaticMarkup(
+      <SituationFiscaleStep
+        showFoyerCard
+        {...baseProps}
+        situationFamiliale="marie"
+        isCouple
+      />,
+    );
+
+    expect(html).toContain('Mutualisation des plafonds (case 6QR)');
+    expect(html.indexOf('Versements retraite')).toBeLessThan(html.indexOf('Mutualisation des plafonds (case 6QR)'));
+  });
+
+  it('renders the conditional revenu rows from the IR-like filters', () => {
+    const html = renderToStaticMarkup(
+      <SituationFiscaleStep
+        showFoyerCard={false}
+        {...baseProps}
+        incomeFilters={{ tns: true, pension: true, foncier: true }}
+      />,
+    );
+
+    expect(html).toContain('TNS');
+    expect(html).toContain('Pension');
+    expect(html).toContain('Foncier');
+    expect(html).toContain('Revenus des associés / gérants');
+    expect(html).toContain('BIC / BNC / BA imposables');
+    expect(html).toContain('Pensions, retraites et rentes');
+    expect(html).toContain('Abattement 10 % pensions (foyer)');
+    expect(html).toContain('Revenus fonciers nets');
   });
 
   it('uses the updated contribution notes without adding unsupported 2042 boxes', () => {
     const html = renderToStaticMarkup(
       <SituationFiscaleStep
-        variant="revenus-n1"
-        yearLabel="2025"
         showFoyerCard={false}
-        situationFamiliale="celibataire"
-        nombreParts={1}
-        isole={false}
-        children={[]}
-        isCouple={false}
-        mutualisationConjoints={false}
-        declarant1={baseDeclarant}
-        declarant2={baseDeclarant}
-        onUpdateSituation={vi.fn()}
-        onAddChild={vi.fn()}
-        onUpdateChildMode={vi.fn()}
-        onRemoveChild={vi.fn()}
-        onUpdateDeclarant={vi.fn()}
+        {...baseProps}
       />,
     );
 

--- a/src/features/per/components/potentiel/steps/SituationFiscaleStep.tsx
+++ b/src/features/per/components/potentiel/steps/SituationFiscaleStep.tsx
@@ -3,6 +3,7 @@
  */
 
 import React from 'react';
+import { SimSelect } from '@/components/ui/sim/SimSelect';
 import type { DeclarantRevenus } from '../../../../../engine/per';
 import type { PerChildDraft } from '../../../utils/perParts';
 import { PerAmountInput } from '../PerAmountInput';
@@ -75,14 +76,15 @@ export default function SituationFiscaleStep({
     label: string;
     note: string;
     key: ContributionFieldKey;
+    tnsOnly?: boolean;
   }[] = [
     { label: 'PER 163 quatervicies', note: variant === 'revenus-n1' ? '2042 : 6NS / 6NT' : 'année en cours', key: 'cotisationsPer163Q' },
     { label: 'PERP et assimilés', note: variant === 'revenus-n1' ? '2042 : 6RS / 6RT' : 'année en cours', key: 'cotisationsPerp' },
     { label: 'Art. 83 employeur + salarié', note: variant === 'revenus-n1' ? '2042 : 6QS / 6QT' : 'année en cours', key: 'cotisationsArt83' },
-    { label: 'PER 154 bis', note: variant === 'revenus-n1' ? '2042 : 6OS / 6OT' : 'année en cours', key: 'cotisationsMadelin154bis' },
-    { label: 'Madelin retraite', note: 'contrat retraite, distinct du PER 154 bis', key: 'cotisationsMadelinRetraite' },
+    { label: 'PER 154 bis', note: variant === 'revenus-n1' ? '2042 : 6OS / 6OT' : 'année en cours', key: 'cotisationsMadelin154bis', tnsOnly: true },
+    { label: 'Madelin retraite', note: 'contrat retraite, distinct du PER 154 bis', key: 'cotisationsMadelinRetraite', tnsOnly: true },
     { label: 'Abondement PERCO', note: 'employeur, réduit le plafond 163Q', key: 'abondementPerco' },
-    { label: 'Prévoyance Madelin', note: 'part non retraite', key: 'cotisationsPrevo' },
+    { label: 'Prévoyance Madelin', note: 'part non retraite', key: 'cotisationsPrevo', tnsOnly: true },
   ];
 
   return (
@@ -97,22 +99,23 @@ export default function SituationFiscaleStep({
           <div className="per-situation-foyer-grid">
             <div className="per-field premium-field" data-testid="per-situation-field">
               <label>Situation familiale</label>
-              <select
-                className="per-select sim-field__control"
+              <SimSelect
                 value={situationFamiliale}
-                onChange={(event) => {
+                onChange={(value) => {
                   onUpdateSituation({
-                    situationFamiliale: event.target.value as 'celibataire' | 'marie',
+                    situationFamiliale: value as 'celibataire' | 'marie',
                   });
                 }}
-              >
-                <option value="celibataire">Célibataire / Veuf / Divorcé</option>
-                <option value="marie">Marié / Pacsé</option>
-              </select>
+                options={[
+                  { value: 'celibataire', label: 'Célibataire / Veuf / Divorcé' },
+                  { value: 'marie', label: 'Marié / Pacsé' },
+                ]}
+              />
               {situationFamiliale === 'celibataire' && (
-                <label className="per-toggle-label per-toggle-label--inline">
+                <label className="per-checkbox-label">
                   <input
                     type="checkbox"
+                    className="per-checkbox"
                     checked={isole}
                     onChange={(event) => onUpdateSituation({ isole: event.target.checked })}
                   />
@@ -138,14 +141,15 @@ export default function SituationFiscaleStep({
                   {children.map((child, index) => (
                     <div key={child.id} className="per-child-row">
                       <span className="per-child-row__label">E{index + 1}</span>
-                      <select
-                        className="per-select sim-field__control per-child-row__select"
+                      <SimSelect
                         value={child.mode}
-                        onChange={(event) => onUpdateChildMode(child.id, event.target.value as PerChildDraft['mode'])}
-                      >
-                        <option value="charge">À charge</option>
-                        <option value="shared">Garde alternée</option>
-                      </select>
+                        onChange={(value) => onUpdateChildMode(child.id, value as PerChildDraft['mode'])}
+                        options={[
+                          { value: 'charge', label: 'À charge' },
+                          { value: 'shared', label: 'Garde alternée' },
+                        ]}
+                        className="per-child-row__select"
+                      />
                       <button
                         type="button"
                         className="per-child-remove-btn"
@@ -184,23 +188,12 @@ export default function SituationFiscaleStep({
           icon="versements"
         />
 
-        {isCouple && (
-          <label className="per-toggle-label per-toggle-label--panel per-contribution-toggle">
-            <input
-              type="checkbox"
-              checked={mutualisationConjoints}
-              onChange={(event) => onUpdateSituation({ mutualisationConjoints: event.target.checked })}
-            />
-            <span>Mutualisation des plafonds (case 6QR)</span>
-          </label>
-        )}
-
         <div className={`per-contribution-table ${isCouple ? 'is-couple' : ''}`}>
           <div className="per-contribution-table-head per-contribution-table-head--label">Catégorie</div>
           <div className="per-contribution-table-head">Déclarant 1</div>
           {isCouple && <div className="per-contribution-table-head">Déclarant 2</div>}
 
-          {contributionRows.map((row) => (
+          {contributionRows.filter(row => !row.tnsOnly || incomeFilters.tns).map((row) => (
             <React.Fragment key={row.key}>
               <div className="per-contribution-table-label">
                 <span>{row.label}</span>
@@ -229,6 +222,17 @@ export default function SituationFiscaleStep({
             </React.Fragment>
           ))}
         </div>
+
+        {isCouple && (
+          <label className="per-toggle-label per-toggle-label--panel per-contribution-toggle">
+            <input
+              type="checkbox"
+              checked={mutualisationConjoints}
+              onChange={(event) => onUpdateSituation({ mutualisationConjoints: event.target.checked })}
+            />
+            <span>Mutualisation des plafonds (case 6QR)</span>
+          </label>
+        )}
       </div>
     </div>
   );

--- a/src/features/per/components/potentiel/steps/SituationFiscaleStep.tsx
+++ b/src/features/per/components/potentiel/steps/SituationFiscaleStep.tsx
@@ -3,7 +3,9 @@
  */
 
 import React from 'react';
-import type { DeclarantRevenus, PerPotentielResult } from '../../../../../engine/per';
+import type { DeclarantRevenus } from '../../../../../engine/per';
+import { PerAmountInput } from '../PerAmountInput';
+import type { PerChildDraft } from '../../../utils/perParts';
 
 export type FiscalStepVariant = 'revenus-n1' | 'projection-n' | 'versements-n';
 
@@ -15,26 +17,21 @@ interface SituationFiscaleStepProps {
   situationFamiliale: 'celibataire' | 'marie';
   nombreParts: number;
   isole: boolean;
+  children: PerChildDraft[];
   isCouple: boolean;
   mutualisationConjoints: boolean;
   declarant1: DeclarantRevenus;
   declarant2: DeclarantRevenus;
-  result: PerPotentielResult | null;
   onUpdateSituation: (_patch: Partial<{
     situationFamiliale: 'celibataire' | 'marie';
-    nombreParts: number;
     isole: boolean;
     mutualisationConjoints: boolean;
   }>) => void;
+  onAddChild: () => void;
+  onUpdateChildMode: (_id: number, _mode: PerChildDraft['mode']) => void;
+  onRemoveChild: (_id: number) => void;
   onUpdateDeclarant: (_decl: 1 | 2, _patch: Partial<DeclarantRevenus>) => void;
 }
-
-const fmtCurrency = (value: number): string =>
-  new Intl.NumberFormat('fr-FR', {
-    style: 'currency',
-    currency: 'EUR',
-    maximumFractionDigits: 0,
-  }).format(value);
 
 type IncomeFieldKey =
   | 'salaires'
@@ -53,87 +50,195 @@ type ContributionFieldKey =
   | 'abondementPerco'
   | 'cotisationsPrevo';
 
-function NumberField({
-  label,
-  value,
-  onChange,
-  min = 0,
-}: {
-  label: string;
-  value: number;
-  onChange: (_value: number) => void;
-  min?: number;
-}): React.ReactElement {
+const incomeFields: { label: string; key: IncomeFieldKey }[] = [
+  { label: 'Traitements et salaires', key: 'salaires' },
+  { label: 'Revenus art. 62', key: 'art62' },
+  { label: 'BIC / BNC / BA', key: 'bic' },
+  { label: 'Pensions et retraites', key: 'retraites' },
+  { label: 'Revenus fonciers nets', key: 'fonciersNets' },
+  { label: 'Autres revenus', key: 'autresRevenus' },
+];
+
+function SectionIcon({ kind }: { kind: 'foyer' | 'revenus' | 'versements' }): React.ReactElement {
+  if (kind === 'foyer') {
+    return (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+        <circle cx="9" cy="7" r="4" />
+        <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+        <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+      </svg>
+    );
+  }
+
+  if (kind === 'revenus') {
+    return (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <rect x="3" y="3" width="18" height="18" rx="2" />
+        <line x1="3" y1="9" x2="21" y2="9" />
+        <line x1="3" y1="15" x2="21" y2="15" />
+        <line x1="12" y1="3" x2="12" y2="21" />
+      </svg>
+    );
+  }
+
   return (
-    <label className="per-field">
-      <span>{label}</span>
-      <input
-        type="number"
-        min={min}
-        className="per-input sim-field__control"
-        value={value || ''}
-        placeholder="0"
-        onChange={(event) => onChange(Number(event.target.value) || 0)}
-      />
-    </label>
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M3 7h18" />
+      <path d="M6 11h12" />
+      <path d="M8 15h8" />
+      <path d="M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Z" />
+    </svg>
   );
 }
 
-function IncomeCard({
-  label,
-  declarant,
-  onChange,
+function SectionHeader({
+  eyebrow,
+  title,
+  subtitle,
+  icon,
 }: {
-  label: string;
-  declarant: DeclarantRevenus;
-  onChange: (_patch: Partial<DeclarantRevenus>) => void;
+  eyebrow: string;
+  title: string;
+  subtitle?: string;
+  icon: 'foyer' | 'revenus' | 'versements';
 }): React.ReactElement {
-  const fields: { label: string; key: IncomeFieldKey }[] = [
-    { label: 'Traitements et salaires', key: 'salaires' },
-    { label: 'Revenus art. 62', key: 'art62' },
-    { label: 'BIC / BNC / BA', key: 'bic' },
-    { label: 'Pensions et retraites', key: 'retraites' },
-    { label: 'Revenus fonciers nets', key: 'fonciersNets' },
-    { label: 'Autres revenus', key: 'autresRevenus' },
-  ];
+  return (
+    <>
+      <div className="sim-card__header sim-card__header--bleed per-section-header">
+        <div className="sim-card__title-row">
+          <div className="sim-card__icon">
+            <SectionIcon kind={icon} />
+          </div>
+          <div className="per-section-title-block">
+            <p className="premium-section-title">{eyebrow}</p>
+            <h3 className="sim-card__title">{title}</h3>
+          </div>
+        </div>
+        {subtitle && <p className="per-section-subtitle">{subtitle}</p>}
+      </div>
+      <div className="sim-divider" />
+    </>
+  );
+}
+
+function PerIncomeTable({
+  yearLabel,
+  incomeCardsOptional,
+  isCouple,
+  declarant1,
+  declarant2,
+  onUpdateDeclarant,
+}: {
+  yearLabel: string;
+  incomeCardsOptional: boolean;
+  isCouple: boolean;
+  declarant1: DeclarantRevenus;
+  declarant2: DeclarantRevenus;
+  onUpdateDeclarant: (_decl: 1 | 2, _patch: Partial<DeclarantRevenus>) => void;
+}): React.ReactElement {
+  const subtitle = incomeCardsOptional
+    ? `Les revenus ${yearLabel} sont facultatifs sur cet écran. Renseignez-les si vous souhaitez affiner la fiscalité liée au versement.`
+    : `Renseignez les revenus ${yearLabel} pour reconstruire le calcul fiscal et les plafonds associés.`;
 
   return (
-    <div className="premium-card per-income-card">
-      <div className="per-income-card-header">
-        <p className="premium-section-title">Déclarant</p>
-        <h4 className="per-income-card-title">{label}</h4>
-      </div>
+    <div className="premium-card premium-card--guide sim-card--guide per-income-table-card">
+      <SectionHeader
+        eyebrow="Revenus"
+        title="Revenus imposables"
+        subtitle={subtitle}
+        icon="revenus"
+      />
 
-      <div className="per-income-grid">
-        {fields.map((field) => (
-          <NumberField
-            key={field.key}
-            label={field.label}
-            value={declarant[field.key]}
-            onChange={(value) => onChange({ [field.key]: value })}
-          />
-        ))}
-      </div>
-
-      <div className="per-income-toggle-row">
-        <label className="per-toggle-label per-toggle-label--inline">
-          <input
-            type="checkbox"
-            checked={declarant.fraisReels}
-            onChange={(event) => onChange({ fraisReels: event.target.checked })}
-          />
-          <span>Frais réels</span>
-        </label>
-
-        {declarant.fraisReels && (
-          <div className="per-income-toggle-field">
-            <NumberField
-              label="Montant des frais réels"
-              value={declarant.fraisReelsMontant}
-              onChange={(value) => onChange({ fraisReelsMontant: value })}
-            />
-          </div>
-        )}
+      <div className="per-income-table-wrap">
+        <table className={`per-income-table ${isCouple ? '' : 'per-income-table--single'}`} aria-label="Revenus imposables">
+          <colgroup>
+            <col style={{ width: '40%' }} />
+            <col style={{ width: isCouple ? '30%' : '60%' }} />
+            {isCouple && <col style={{ width: '30%' }} />}
+          </colgroup>
+          <thead>
+            <tr>
+              <th aria-label="Catégorie"></th>
+              <th>Déclarant 1</th>
+              {isCouple && <th>Déclarant 2</th>}
+            </tr>
+          </thead>
+          <tbody>
+            {incomeFields.map((field) => (
+              <tr key={field.key}>
+                <td>{field.label}</td>
+                <td data-column-label="Déclarant 1">
+                  <PerAmountInput
+                    value={declarant1[field.key]}
+                    ariaLabel={`${field.label} déclarant 1`}
+                    className="per-income-table-input"
+                    onChange={(value) => onUpdateDeclarant(1, { [field.key]: value })}
+                  />
+                </td>
+                {isCouple && (
+                  <td data-column-label="Déclarant 2">
+                    <PerAmountInput
+                      value={declarant2[field.key]}
+                      ariaLabel={`${field.label} déclarant 2`}
+                      className="per-income-table-input"
+                      onChange={(value) => onUpdateDeclarant(2, { [field.key]: value })}
+                    />
+                  </td>
+                )}
+              </tr>
+            ))}
+            <tr className="per-income-table-row-title">
+              <td>Frais réels ou abattement 10 %</td>
+              <td data-column-label="Déclarant 1">
+                <div className="per-income-real-cell">
+                  <select
+                    className="per-select sim-field__control per-income-real-select"
+                    value={declarant1.fraisReels ? 'reels' : 'abat10'}
+                    onChange={(event) => onUpdateDeclarant(1, { fraisReels: event.target.value === 'reels' })}
+                  >
+                    <option value="abat10">10 %</option>
+                    <option value="reels">FR</option>
+                  </select>
+                  {declarant1.fraisReels ? (
+                    <PerAmountInput
+                      value={declarant1.fraisReelsMontant}
+                      ariaLabel="Montant des frais réels déclarant 1"
+                      className="per-income-table-input"
+                      onChange={(value) => onUpdateDeclarant(1, { fraisReelsMontant: value })}
+                    />
+                  ) : (
+                    <div className="per-income-readonly">Abattement 10 % automatique</div>
+                  )}
+                </div>
+              </td>
+              {isCouple && (
+                <td data-column-label="Déclarant 2">
+                  <div className="per-income-real-cell">
+                    <select
+                      className="per-select sim-field__control per-income-real-select"
+                      value={declarant2.fraisReels ? 'reels' : 'abat10'}
+                      onChange={(event) => onUpdateDeclarant(2, { fraisReels: event.target.value === 'reels' })}
+                    >
+                      <option value="abat10">10 %</option>
+                      <option value="reels">FR</option>
+                    </select>
+                    {declarant2.fraisReels ? (
+                      <PerAmountInput
+                        value={declarant2.fraisReelsMontant}
+                        ariaLabel="Montant des frais réels déclarant 2"
+                        className="per-income-table-input"
+                        onChange={(value) => onUpdateDeclarant(2, { fraisReelsMontant: value })}
+                      />
+                    ) : (
+                      <div className="per-income-readonly">Abattement 10 % automatique</div>
+                    )}
+                  </div>
+                </td>
+              )}
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
   );
@@ -147,12 +252,15 @@ export default function SituationFiscaleStep({
   situationFamiliale,
   nombreParts,
   isole,
+  children,
   isCouple,
   mutualisationConjoints,
   declarant1,
   declarant2,
-  result,
   onUpdateSituation,
+  onAddChild,
+  onUpdateChildMode,
+  onRemoveChild,
   onUpdateDeclarant,
 }: SituationFiscaleStepProps): React.ReactElement {
   const contributionRows: {
@@ -164,120 +272,133 @@ export default function SituationFiscaleStep({
     { label: 'PERP et assimilés', note: variant === 'revenus-n1' ? '2042 : 6RS / 6RT' : 'année en cours', key: 'cotisationsPerp' },
     { label: 'Art. 83 employeur + salarié', note: variant === 'revenus-n1' ? '2042 : 6QS / 6QT' : 'année en cours', key: 'cotisationsArt83' },
     { label: 'PER 154 bis', note: variant === 'revenus-n1' ? '2042 : 6OS / 6OT' : 'année en cours', key: 'cotisationsMadelin154bis' },
-    { label: 'Madelin retraite', note: 'hors 154 bis', key: 'cotisationsMadelinRetraite' },
-    { label: 'Abondement PERCO', note: 'employeur', key: 'abondementPerco' },
+    { label: 'Madelin retraite', note: 'contrat retraite, distinct du PER 154 bis', key: 'cotisationsMadelinRetraite' },
+    { label: 'Abondement PERCO', note: 'employeur, réduit le plafond 163Q', key: 'abondementPerco' },
     { label: 'Prévoyance Madelin', note: 'part non retraite', key: 'cotisationsPrevo' },
   ];
 
   return (
     <div className="per-step per-step--situation">
-      <div className={`per-situation-top ${showFoyerCard ? '' : 'per-situation-top--single'}`}>
-        {showFoyerCard && (
-          <div className="premium-card per-situation-card">
-            <div className="per-situation-card-header">
-              <p className="premium-section-title">Foyer</p>
-              <h4 className="per-situation-card-title">Situation familiale</h4>
+      {showFoyerCard && (
+        <div className="premium-card premium-card--guide sim-card--guide per-situation-card">
+          <SectionHeader
+            eyebrow="Foyer"
+            title="Situation familiale"
+            subtitle="Renseignez le foyer pour recalculer automatiquement le nombre de parts."
+            icon="foyer"
+          />
+
+          <div className="per-situation-foyer-grid">
+            <label className="per-field">
+              <span>Situation familiale</span>
+              <select
+                className="per-select sim-field__control"
+                value={situationFamiliale}
+                onChange={(event) => {
+                  onUpdateSituation({
+                    situationFamiliale: event.target.value as 'celibataire' | 'marie',
+                  });
+                }}
+              >
+                <option value="marie">Marié / Pacsé</option>
+                <option value="celibataire">Célibataire / Veuf / Divorcé</option>
+              </select>
+            </label>
+
+            <div className="per-parts-summary" aria-live="polite">
+              <span className="per-parts-summary__label">Nombre de parts calculé</span>
+              <strong className="per-parts-summary__value">{nombreParts.toLocaleString('fr-FR')}</strong>
             </div>
 
-            <div className="per-situation-foyer-grid">
-              <label className="per-field">
-                <span>Situation familiale</span>
-                <select
-                  className="per-select sim-field__control"
-                  value={situationFamiliale}
-                  onChange={(event) => {
-                    onUpdateSituation({
-                      situationFamiliale: event.target.value as 'celibataire' | 'marie',
-                    });
-                  }}
-                >
-                  <option value="marie">Marié / Pacsé</option>
-                  <option value="celibataire">Célibataire / Veuf / Divorcé</option>
-                </select>
+            {situationFamiliale === 'celibataire' && (
+              <label className="per-toggle-label per-toggle-label--panel">
+                <input
+                  type="checkbox"
+                  checked={isole}
+                  onChange={(event) => onUpdateSituation({ isole: event.target.checked })}
+                />
+                <span>Parent isolé</span>
               </label>
+            )}
 
-              <NumberField
-                label="Nombre de parts"
-                value={nombreParts}
-                min={1}
-                onChange={(value) => onUpdateSituation({ nombreParts: Math.max(1, value) })}
-              />
-
-              {situationFamiliale === 'celibataire' && (
-                <label className="per-toggle-label per-toggle-label--panel">
-                  <input
-                    type="checkbox"
-                    checked={isole}
-                    onChange={(event) => onUpdateSituation({ isole: event.target.checked })}
-                  />
-                  <span>Parent isolé</span>
-                </label>
-              )}
-
-              {isCouple && (
-                <label className="per-toggle-label per-toggle-label--panel">
-                  <input
-                    type="checkbox"
-                    checked={mutualisationConjoints}
-                    onChange={(event) => onUpdateSituation({ mutualisationConjoints: event.target.checked })}
-                  />
-                  <span>Mutualisation des plafonds (case 6QR)</span>
-                </label>
-              )}
-            </div>
-          </div>
-        )}
-
-        <div className="premium-card per-situation-card per-situation-card--accent">
-          <div className="per-situation-card-header">
-            <p className="premium-section-title">Aperçu fiscal</p>
-            <h4 className="per-situation-card-title">Estimation mise à jour en direct</h4>
+            {isCouple && (
+              <label className="per-toggle-label per-toggle-label--panel">
+                <input
+                  type="checkbox"
+                  checked={mutualisationConjoints}
+                  onChange={(event) => onUpdateSituation({ mutualisationConjoints: event.target.checked })}
+                />
+                <span>Mutualisation des plafonds (case 6QR)</span>
+              </label>
+            )}
           </div>
 
-          {result ? (
-            <div className="per-situation-kpis">
-              <div className="per-situation-kpi">
-                <span className="per-situation-kpi-label">TMI</span>
-                <strong className="per-situation-kpi-value">
-                  {(result.situationFiscale.tmi <= 1
-                    ? result.situationFiscale.tmi * 100
-                    : result.situationFiscale.tmi).toFixed(1)} %
-                </strong>
-              </div>
-              <div className="per-situation-kpi">
-                <span className="per-situation-kpi-label">IR estimé</span>
-                <strong className="per-situation-kpi-value">
-                  {fmtCurrency(result.situationFiscale.irEstime)}
-                </strong>
-              </div>
-              <div className="per-situation-kpi">
-                <span className="per-situation-kpi-label">Revenu imposable D1</span>
-                <strong className="per-situation-kpi-value">
-                  {fmtCurrency(result.situationFiscale.revenuImposableD1)}
-                </strong>
-              </div>
-              {isCouple && (
-                <div className="per-situation-kpi">
-                  <span className="per-situation-kpi-label">Revenu imposable D2</span>
-                  <strong className="per-situation-kpi-value">
-                    {fmtCurrency(result.situationFiscale.revenuImposableD2)}
-                  </strong>
-                </div>
-              )}
+          <div className="per-children-zone">
+            <div className="per-children-header">
+              <p className="per-children-title">Enfants à charge</p>
+              <button
+                type="button"
+                className="per-child-add-btn"
+                onClick={onAddChild}
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <line x1="12" y1="5" x2="12" y2="19" />
+                  <line x1="5" y1="12" x2="19" y2="12" />
+                </svg>
+                Ajouter un enfant
+              </button>
             </div>
-          ) : (
-            <p className="per-situation-note">
-              Le moteur fiscal se met à jour dès que les revenus et versements sont saisis.
-            </p>
-          )}
-        </div>
-      </div>
 
-      <div className="premium-card per-contribution-card">
-        <div className="per-situation-card-header">
-          <p className="premium-section-title">Versements retraite</p>
-          <h4 className="per-situation-card-title">Montants {yearLabel} par déclarant</h4>
+            {children.length === 0 ? (
+              <p className="per-situation-note">Aucun enfant renseigné.</p>
+            ) : (
+              <div className="per-children-list">
+                {children.map((child, index) => (
+                  <div key={child.id} className="per-child-row">
+                    <span className="per-child-row__label">E{index + 1}</span>
+                    <select
+                      className="per-select sim-field__control per-child-row__select"
+                      value={child.mode}
+                      onChange={(event) => onUpdateChildMode(child.id, event.target.value as PerChildDraft['mode'])}
+                    >
+                      <option value="charge">À charge</option>
+                      <option value="shared">Garde alternée</option>
+                    </select>
+                    <button
+                      type="button"
+                      className="per-child-remove-btn"
+                      onClick={() => onRemoveChild(child.id)}
+                      aria-label={`Supprimer enfant ${index + 1}`}
+                    >
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                        <line x1="18" y1="6" x2="6" y2="18" />
+                        <line x1="6" y1="6" x2="18" y2="18" />
+                      </svg>
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
+      )}
+
+      <PerIncomeTable
+        yearLabel={yearLabel}
+        incomeCardsOptional={incomeCardsOptional}
+        isCouple={isCouple}
+        declarant1={declarant1}
+        declarant2={declarant2}
+        onUpdateDeclarant={onUpdateDeclarant}
+      />
+
+      <div className="premium-card premium-card--guide sim-card--guide per-contribution-card">
+        <SectionHeader
+          eyebrow="Versements retraite"
+          title={`Montants ${yearLabel} par déclarant`}
+          subtitle="Renseignez les montants déclarés ou estimés pour chaque enveloppe de retraite."
+          icon="versements"
+        />
 
         <div className={`per-contribution-table ${isCouple ? 'is-couple' : ''}`}>
           <div className="per-contribution-table-head per-contribution-table-head--label">Catégorie</div>
@@ -292,56 +413,27 @@ export default function SituationFiscaleStep({
               </div>
               <div className="per-contribution-table-cell">
                 <span className="per-contribution-mobile-label">Déclarant 1</span>
-                <input
-                  type="number"
-                  min={0}
-                  className="per-input sim-field__control"
-                  value={declarant1[row.key] || ''}
-                  placeholder="0"
-                  onChange={(event) => onUpdateDeclarant(1, { [row.key]: Number(event.target.value) || 0 })}
+                <PerAmountInput
+                  value={declarant1[row.key]}
+                  ariaLabel={`${row.label} déclarant 1`}
+                  className="per-contribution-input"
+                  onChange={(value) => onUpdateDeclarant(1, { [row.key]: value })}
                 />
               </div>
               {isCouple && (
                 <div className="per-contribution-table-cell">
                   <span className="per-contribution-mobile-label">Déclarant 2</span>
-                  <input
-                    type="number"
-                    min={0}
-                    className="per-input sim-field__control"
-                    value={declarant2[row.key] || ''}
-                    placeholder="0"
-                    onChange={(event) => onUpdateDeclarant(2, { [row.key]: Number(event.target.value) || 0 })}
+                  <PerAmountInput
+                    value={declarant2[row.key]}
+                    ariaLabel={`${row.label} déclarant 2`}
+                    className="per-contribution-input"
+                    onChange={(value) => onUpdateDeclarant(2, { [row.key]: value })}
                   />
                 </div>
               )}
             </React.Fragment>
           ))}
         </div>
-      </div>
-
-      <div className="per-situation-income-copy">
-        <p className="premium-section-title">Revenus</p>
-        <p className="per-situation-note">
-          {incomeCardsOptional
-            ? `Les revenus ${yearLabel} sont facultatifs sur cet écran. Renseignez-les si vous souhaitez affiner la fiscalité liée au versement.`
-            : `Renseignez les revenus ${yearLabel} pour reconstruire le calcul fiscal et les plafonds associés.`}
-        </p>
-      </div>
-
-      <div className={`per-declarants-grid ${isCouple ? 'is-couple' : ''}`}>
-        <IncomeCard
-          label="Déclarant 1"
-          declarant={declarant1}
-          onChange={(patch) => onUpdateDeclarant(1, patch)}
-        />
-
-        {isCouple && (
-          <IncomeCard
-            label="Déclarant 2"
-            declarant={declarant2}
-            onChange={(patch) => onUpdateDeclarant(2, patch)}
-          />
-        )}
       </div>
     </div>
   );

--- a/src/features/per/components/potentiel/steps/SituationFiscaleStep.tsx
+++ b/src/features/per/components/potentiel/steps/SituationFiscaleStep.tsx
@@ -4,8 +4,14 @@
 
 import React from 'react';
 import type { DeclarantRevenus } from '../../../../../engine/per';
-import { PerAmountInput } from '../PerAmountInput';
 import type { PerChildDraft } from '../../../utils/perParts';
+import { PerAmountInput } from '../PerAmountInput';
+import {
+  PerIncomeTable,
+  SectionHeader,
+  type PerAbattementConfig,
+  type PerIncomeFilters,
+} from './PerIncomeTable';
 
 export type FiscalStepVariant = 'revenus-n1' | 'projection-n' | 'versements-n';
 
@@ -13,15 +19,16 @@ interface SituationFiscaleStepProps {
   variant: FiscalStepVariant;
   yearLabel: string;
   showFoyerCard: boolean;
-  incomeCardsOptional?: boolean;
   situationFamiliale: 'celibataire' | 'marie';
-  nombreParts: number;
   isole: boolean;
   children: PerChildDraft[];
   isCouple: boolean;
   mutualisationConjoints: boolean;
   declarant1: DeclarantRevenus;
   declarant2: DeclarantRevenus;
+  incomeFilters: PerIncomeFilters;
+  abat10SalCfg: PerAbattementConfig;
+  abat10RetCfg: PerAbattementConfig;
   onUpdateSituation: (_patch: Partial<{
     situationFamiliale: 'celibataire' | 'marie';
     isole: boolean;
@@ -30,16 +37,9 @@ interface SituationFiscaleStepProps {
   onAddChild: () => void;
   onUpdateChildMode: (_id: number, _mode: PerChildDraft['mode']) => void;
   onRemoveChild: (_id: number) => void;
+  onToggleIncomeFilter: (_key: keyof PerIncomeFilters) => void;
   onUpdateDeclarant: (_decl: 1 | 2, _patch: Partial<DeclarantRevenus>) => void;
 }
-
-type IncomeFieldKey =
-  | 'salaires'
-  | 'art62'
-  | 'bic'
-  | 'retraites'
-  | 'fonciersNets'
-  | 'autresRevenus';
 
 type ContributionFieldKey =
   | 'cotisationsPer163Q'
@@ -50,217 +50,25 @@ type ContributionFieldKey =
   | 'abondementPerco'
   | 'cotisationsPrevo';
 
-const incomeFields: { label: string; key: IncomeFieldKey }[] = [
-  { label: 'Traitements et salaires', key: 'salaires' },
-  { label: 'Revenus art. 62', key: 'art62' },
-  { label: 'BIC / BNC / BA', key: 'bic' },
-  { label: 'Pensions et retraites', key: 'retraites' },
-  { label: 'Revenus fonciers nets', key: 'fonciersNets' },
-  { label: 'Autres revenus', key: 'autresRevenus' },
-];
-
-function SectionIcon({ kind }: { kind: 'foyer' | 'revenus' | 'versements' }): React.ReactElement {
-  if (kind === 'foyer') {
-    return (
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-        <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
-        <circle cx="9" cy="7" r="4" />
-        <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
-        <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-      </svg>
-    );
-  }
-
-  if (kind === 'revenus') {
-    return (
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-        <rect x="3" y="3" width="18" height="18" rx="2" />
-        <line x1="3" y1="9" x2="21" y2="9" />
-        <line x1="3" y1="15" x2="21" y2="15" />
-        <line x1="12" y1="3" x2="12" y2="21" />
-      </svg>
-    );
-  }
-
-  return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <path d="M3 7h18" />
-      <path d="M6 11h12" />
-      <path d="M8 15h8" />
-      <path d="M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Z" />
-    </svg>
-  );
-}
-
-function SectionHeader({
-  eyebrow,
-  title,
-  subtitle,
-  icon,
-}: {
-  eyebrow: string;
-  title: string;
-  subtitle?: string;
-  icon: 'foyer' | 'revenus' | 'versements';
-}): React.ReactElement {
-  return (
-    <>
-      <div className="sim-card__header sim-card__header--bleed per-section-header">
-        <div className="sim-card__title-row">
-          <div className="sim-card__icon">
-            <SectionIcon kind={icon} />
-          </div>
-          <div className="per-section-title-block">
-            <p className="premium-section-title">{eyebrow}</p>
-            <h3 className="sim-card__title">{title}</h3>
-          </div>
-        </div>
-        {subtitle && <p className="per-section-subtitle">{subtitle}</p>}
-      </div>
-      <div className="sim-divider" />
-    </>
-  );
-}
-
-function PerIncomeTable({
-  yearLabel,
-  incomeCardsOptional,
-  isCouple,
-  declarant1,
-  declarant2,
-  onUpdateDeclarant,
-}: {
-  yearLabel: string;
-  incomeCardsOptional: boolean;
-  isCouple: boolean;
-  declarant1: DeclarantRevenus;
-  declarant2: DeclarantRevenus;
-  onUpdateDeclarant: (_decl: 1 | 2, _patch: Partial<DeclarantRevenus>) => void;
-}): React.ReactElement {
-  const subtitle = incomeCardsOptional
-    ? `Les revenus ${yearLabel} sont facultatifs sur cet écran. Renseignez-les si vous souhaitez affiner la fiscalité liée au versement.`
-    : `Renseignez les revenus ${yearLabel} pour reconstruire le calcul fiscal et les plafonds associés.`;
-
-  return (
-    <div className="premium-card premium-card--guide sim-card--guide per-income-table-card">
-      <SectionHeader
-        eyebrow="Revenus"
-        title="Revenus imposables"
-        subtitle={subtitle}
-        icon="revenus"
-      />
-
-      <div className="per-income-table-wrap">
-        <table className={`per-income-table ${isCouple ? '' : 'per-income-table--single'}`} aria-label="Revenus imposables">
-          <colgroup>
-            <col style={{ width: '40%' }} />
-            <col style={{ width: isCouple ? '30%' : '60%' }} />
-            {isCouple && <col style={{ width: '30%' }} />}
-          </colgroup>
-          <thead>
-            <tr>
-              <th aria-label="Catégorie"></th>
-              <th>Déclarant 1</th>
-              {isCouple && <th>Déclarant 2</th>}
-            </tr>
-          </thead>
-          <tbody>
-            {incomeFields.map((field) => (
-              <tr key={field.key}>
-                <td>{field.label}</td>
-                <td data-column-label="Déclarant 1">
-                  <PerAmountInput
-                    value={declarant1[field.key]}
-                    ariaLabel={`${field.label} déclarant 1`}
-                    className="per-income-table-input"
-                    onChange={(value) => onUpdateDeclarant(1, { [field.key]: value })}
-                  />
-                </td>
-                {isCouple && (
-                  <td data-column-label="Déclarant 2">
-                    <PerAmountInput
-                      value={declarant2[field.key]}
-                      ariaLabel={`${field.label} déclarant 2`}
-                      className="per-income-table-input"
-                      onChange={(value) => onUpdateDeclarant(2, { [field.key]: value })}
-                    />
-                  </td>
-                )}
-              </tr>
-            ))}
-            <tr className="per-income-table-row-title">
-              <td>Frais réels ou abattement 10 %</td>
-              <td data-column-label="Déclarant 1">
-                <div className="per-income-real-cell">
-                  <select
-                    className="per-select sim-field__control per-income-real-select"
-                    value={declarant1.fraisReels ? 'reels' : 'abat10'}
-                    onChange={(event) => onUpdateDeclarant(1, { fraisReels: event.target.value === 'reels' })}
-                  >
-                    <option value="abat10">10 %</option>
-                    <option value="reels">FR</option>
-                  </select>
-                  {declarant1.fraisReels ? (
-                    <PerAmountInput
-                      value={declarant1.fraisReelsMontant}
-                      ariaLabel="Montant des frais réels déclarant 1"
-                      className="per-income-table-input"
-                      onChange={(value) => onUpdateDeclarant(1, { fraisReelsMontant: value })}
-                    />
-                  ) : (
-                    <div className="per-income-readonly">Abattement 10 % automatique</div>
-                  )}
-                </div>
-              </td>
-              {isCouple && (
-                <td data-column-label="Déclarant 2">
-                  <div className="per-income-real-cell">
-                    <select
-                      className="per-select sim-field__control per-income-real-select"
-                      value={declarant2.fraisReels ? 'reels' : 'abat10'}
-                      onChange={(event) => onUpdateDeclarant(2, { fraisReels: event.target.value === 'reels' })}
-                    >
-                      <option value="abat10">10 %</option>
-                      <option value="reels">FR</option>
-                    </select>
-                    {declarant2.fraisReels ? (
-                      <PerAmountInput
-                        value={declarant2.fraisReelsMontant}
-                        ariaLabel="Montant des frais réels déclarant 2"
-                        className="per-income-table-input"
-                        onChange={(value) => onUpdateDeclarant(2, { fraisReelsMontant: value })}
-                      />
-                    ) : (
-                      <div className="per-income-readonly">Abattement 10 % automatique</div>
-                    )}
-                  </div>
-                </td>
-              )}
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-  );
-}
-
 export default function SituationFiscaleStep({
   variant,
   yearLabel,
   showFoyerCard,
-  incomeCardsOptional = false,
   situationFamiliale,
-  nombreParts,
   isole,
   children,
   isCouple,
   mutualisationConjoints,
   declarant1,
   declarant2,
+  incomeFilters,
+  abat10SalCfg,
+  abat10RetCfg,
   onUpdateSituation,
   onAddChild,
   onUpdateChildMode,
   onRemoveChild,
+  onToggleIncomeFilter,
   onUpdateDeclarant,
 }: SituationFiscaleStepProps): React.ReactElement {
   const contributionRows: {
@@ -282,15 +90,13 @@ export default function SituationFiscaleStep({
       {showFoyerCard && (
         <div className="premium-card premium-card--guide sim-card--guide per-situation-card">
           <SectionHeader
-            eyebrow="Foyer"
             title="Situation familiale"
-            subtitle="Renseignez le foyer pour recalculer automatiquement le nombre de parts."
             icon="foyer"
           />
 
           <div className="per-situation-foyer-grid">
-            <label className="per-field">
-              <span>Situation familiale</span>
+            <div className="per-field premium-field" data-testid="per-situation-field">
+              <label>Situation familiale</label>
               <select
                 className="per-select sim-field__control"
                 value={situationFamiliale}
@@ -300,42 +106,22 @@ export default function SituationFiscaleStep({
                   });
                 }}
               >
-                <option value="marie">Marié / Pacsé</option>
                 <option value="celibataire">Célibataire / Veuf / Divorcé</option>
+                <option value="marie">Marié / Pacsé</option>
               </select>
-            </label>
-
-            <div className="per-parts-summary" aria-live="polite">
-              <span className="per-parts-summary__label">Nombre de parts calculé</span>
-              <strong className="per-parts-summary__value">{nombreParts.toLocaleString('fr-FR')}</strong>
+              {situationFamiliale === 'celibataire' && (
+                <label className="per-toggle-label per-toggle-label--inline">
+                  <input
+                    type="checkbox"
+                    checked={isole}
+                    onChange={(event) => onUpdateSituation({ isole: event.target.checked })}
+                  />
+                  <span>Parent isolé</span>
+                </label>
+              )}
             </div>
 
-            {situationFamiliale === 'celibataire' && (
-              <label className="per-toggle-label per-toggle-label--panel">
-                <input
-                  type="checkbox"
-                  checked={isole}
-                  onChange={(event) => onUpdateSituation({ isole: event.target.checked })}
-                />
-                <span>Parent isolé</span>
-              </label>
-            )}
-
-            {isCouple && (
-              <label className="per-toggle-label per-toggle-label--panel">
-                <input
-                  type="checkbox"
-                  checked={mutualisationConjoints}
-                  onChange={(event) => onUpdateSituation({ mutualisationConjoints: event.target.checked })}
-                />
-                <span>Mutualisation des plafonds (case 6QR)</span>
-              </label>
-            )}
-          </div>
-
-          <div className="per-children-zone">
-            <div className="per-children-header">
-              <p className="per-children-title">Enfants à charge</p>
+            <div className="per-children-zone">
               <button
                 type="button"
                 className="per-child-add-btn"
@@ -347,58 +133,67 @@ export default function SituationFiscaleStep({
                 </svg>
                 Ajouter un enfant
               </button>
+              {children.length > 0 && (
+                <div className="per-children-list">
+                  {children.map((child, index) => (
+                    <div key={child.id} className="per-child-row">
+                      <span className="per-child-row__label">E{index + 1}</span>
+                      <select
+                        className="per-select sim-field__control per-child-row__select"
+                        value={child.mode}
+                        onChange={(event) => onUpdateChildMode(child.id, event.target.value as PerChildDraft['mode'])}
+                      >
+                        <option value="charge">À charge</option>
+                        <option value="shared">Garde alternée</option>
+                      </select>
+                      <button
+                        type="button"
+                        className="per-child-remove-btn"
+                        onClick={() => onRemoveChild(child.id)}
+                        aria-label={`Supprimer enfant ${index + 1}`}
+                      >
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                          <line x1="18" y1="6" x2="6" y2="18" />
+                          <line x1="6" y1="6" x2="18" y2="18" />
+                        </svg>
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
-
-            {children.length === 0 ? (
-              <p className="per-situation-note">Aucun enfant renseigné.</p>
-            ) : (
-              <div className="per-children-list">
-                {children.map((child, index) => (
-                  <div key={child.id} className="per-child-row">
-                    <span className="per-child-row__label">E{index + 1}</span>
-                    <select
-                      className="per-select sim-field__control per-child-row__select"
-                      value={child.mode}
-                      onChange={(event) => onUpdateChildMode(child.id, event.target.value as PerChildDraft['mode'])}
-                    >
-                      <option value="charge">À charge</option>
-                      <option value="shared">Garde alternée</option>
-                    </select>
-                    <button
-                      type="button"
-                      className="per-child-remove-btn"
-                      onClick={() => onRemoveChild(child.id)}
-                      aria-label={`Supprimer enfant ${index + 1}`}
-                    >
-                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                        <line x1="18" y1="6" x2="6" y2="18" />
-                        <line x1="6" y1="6" x2="18" y2="18" />
-                      </svg>
-                    </button>
-                  </div>
-                ))}
-              </div>
-            )}
           </div>
         </div>
       )}
 
       <PerIncomeTable
-        yearLabel={yearLabel}
-        incomeCardsOptional={incomeCardsOptional}
         isCouple={isCouple}
         declarant1={declarant1}
         declarant2={declarant2}
+        incomeFilters={incomeFilters}
+        abat10SalCfg={abat10SalCfg}
+        abat10RetCfg={abat10RetCfg}
+        onToggleIncomeFilter={onToggleIncomeFilter}
         onUpdateDeclarant={onUpdateDeclarant}
       />
 
       <div className="premium-card premium-card--guide sim-card--guide per-contribution-card">
         <SectionHeader
-          eyebrow="Versements retraite"
-          title={`Montants ${yearLabel} par déclarant`}
-          subtitle="Renseignez les montants déclarés ou estimés pour chaque enveloppe de retraite."
+          title="Versements retraite"
+          subtitle={`Renseignez les montants ${yearLabel} par déclarant pour chaque enveloppe de retraite.`}
           icon="versements"
         />
+
+        {isCouple && (
+          <label className="per-toggle-label per-toggle-label--panel per-contribution-toggle">
+            <input
+              type="checkbox"
+              checked={mutualisationConjoints}
+              onChange={(event) => onUpdateSituation({ mutualisationConjoints: event.target.checked })}
+            />
+            <span>Mutualisation des plafonds (case 6QR)</span>
+          </label>
+        )}
 
         <div className={`per-contribution-table ${isCouple ? 'is-couple' : ''}`}>
           <div className="per-contribution-table-head per-contribution-table-head--label">Catégorie</div>

--- a/src/features/per/hooks/usePerPotentiel.ts
+++ b/src/features/per/hooks/usePerPotentiel.ts
@@ -16,8 +16,9 @@ import type {
 } from '../../../engine/per';
 import type { FiscalContext } from '../../../hooks/useFiscalContext';
 import { getAvisReferenceYears, getPerWorkflowYears } from '../utils/perWorkflowYears';
+import { derivePerNombreParts, type PerChildDraft } from '../utils/perParts';
 
-const SESSION_KEY = 'ser1:sim:per:potentiel:v2';
+const SESSION_KEY = 'ser1:sim:per:potentiel:v3';
 
 export type PerMode = 'versement-n' | 'declaration-n1';
 export type WizardStep = 1 | 2 | 3 | 4 | 5;
@@ -33,6 +34,7 @@ export interface PerPotentielState {
   situationFamiliale: 'celibataire' | 'marie';
   nombreParts: number;
   isole: boolean;
+  children: PerChildDraft[];
   revenusN1Declarant1: DeclarantRevenus;
   revenusN1Declarant2: DeclarantRevenus;
   projectionNDeclarant1: DeclarantRevenus;
@@ -59,8 +61,44 @@ const EMPTY_DECLARANT: DeclarantRevenus = {
   cotisationsPrevo: 0,
 };
 
-function makeDefaultState(): PerPotentielState {
+function normalizeChildren(children: PerChildDraft[] | null | undefined): PerChildDraft[] {
+  return Array.isArray(children)
+    ? children
+      .filter((child): child is PerChildDraft => Boolean(child) && (child.mode === 'charge' || child.mode === 'shared'))
+      .map((child, index) => ({
+        id: Number.isFinite(child.id) ? child.id : index + 1,
+        mode: child.mode,
+      }))
+    : [];
+}
+
+function normalizeState(state: PerPotentielState): PerPotentielState {
+  const situationFamiliale = state.situationFamiliale;
+  const children = normalizeChildren(state.children);
+  const isole = situationFamiliale === 'marie' ? false : state.isole;
+  const mutualisationConjoints = situationFamiliale === 'marie'
+    ? state.mutualisationConjoints
+    : false;
+
   return {
+    ...state,
+    isole,
+    children,
+    mutualisationConjoints,
+    nombreParts: derivePerNombreParts({
+      situationFamiliale,
+      isole,
+      children,
+    }),
+  };
+}
+
+function getNextChildId(children: PerChildDraft[]): number {
+  return children.reduce((maxId, child) => Math.max(maxId, child.id), 0) + 1;
+}
+
+function makeDefaultState(): PerPotentielState {
+  return normalizeState({
     step: 1,
     mode: null,
     historicalBasis: null,
@@ -70,13 +108,14 @@ function makeDefaultState(): PerPotentielState {
     situationFamiliale: 'celibataire',
     nombreParts: 1,
     isole: false,
+    children: [],
     revenusN1Declarant1: { ...EMPTY_DECLARANT },
     revenusN1Declarant2: { ...EMPTY_DECLARANT },
     projectionNDeclarant1: { ...EMPTY_DECLARANT },
     projectionNDeclarant2: { ...EMPTY_DECLARANT },
     versementEnvisage: 0,
     mutualisationConjoints: false,
-  };
+  });
 }
 
 function loadSession(): PerPotentielState | null {
@@ -87,14 +126,15 @@ function loadSession(): PerPotentielState | null {
     if (!parsed || typeof parsed !== 'object' || !('historicalBasis' in parsed)) {
       return null;
     }
-    return {
+    return normalizeState({
       ...makeDefaultState(),
       ...parsed,
       revenusN1Declarant1: { ...EMPTY_DECLARANT, ...parsed.revenusN1Declarant1 },
       revenusN1Declarant2: { ...EMPTY_DECLARANT, ...parsed.revenusN1Declarant2 },
       projectionNDeclarant1: { ...EMPTY_DECLARANT, ...parsed.projectionNDeclarant1 },
       projectionNDeclarant2: { ...EMPTY_DECLARANT, ...parsed.projectionNDeclarant2 },
-    };
+      children: normalizeChildren(parsed.children),
+    });
   } catch {
     return null;
   }
@@ -149,8 +189,11 @@ export interface UsePerPotentielReturn {
   setHistoricalBasis: (_basis: PerHistoricalBasis) => void;
   setNeedsCurrentYearEstimate: (_value: boolean) => void;
   updateAvisIr: (_patch: Partial<AvisIrPlafonds>, _decl?: 1 | 2) => void;
-  updateSituation: (_patch: Partial<Pick<PerPotentielState, 'situationFamiliale' | 'nombreParts' | 'isole' | 'mutualisationConjoints'>>) => void;
+  updateSituation: (_patch: Partial<Pick<PerPotentielState, 'situationFamiliale' | 'isole' | 'mutualisationConjoints'>>) => void;
   updateDeclarant: (_scope: PerDeclarantScope, _decl: 1 | 2, _patch: Partial<DeclarantRevenus>) => void;
+  addChild: () => void;
+  updateChildMode: (_childId: number, _mode: PerChildDraft['mode']) => void;
+  removeChild: (_childId: number) => void;
   setVersementEnvisage: (_v: number) => void;
   nextStep: () => void;
   prevStep: () => void;
@@ -169,8 +212,9 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
   );
 
   const persist = useCallback((next: PerPotentielState) => {
-    setState(next);
-    saveSession(next);
+    const normalized = normalizeState(next);
+    setState(normalized);
+    saveSession(normalized);
   }, []);
 
   const setMode = useCallback((mode: PerMode) => {
@@ -220,7 +264,7 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
     persist({ ...state, [key]: { ...current, ...patch, anneeRef: current.anneeRef || avisContext.incomeYear } });
   }, [state, persist, years]);
 
-  const updateSituation = useCallback((patch: Partial<Pick<PerPotentielState, 'situationFamiliale' | 'nombreParts' | 'isole' | 'mutualisationConjoints'>>) => {
+  const updateSituation = useCallback((patch: Partial<Pick<PerPotentielState, 'situationFamiliale' | 'isole' | 'mutualisationConjoints'>>) => {
     persist({ ...state, ...patch });
   }, [state, persist]);
 
@@ -229,6 +273,32 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
       ? (decl === 1 ? 'revenusN1Declarant1' : 'revenusN1Declarant2')
       : (decl === 1 ? 'projectionNDeclarant1' : 'projectionNDeclarant2');
     persist({ ...state, [key]: { ...state[key], ...patch } });
+  }, [state, persist]);
+
+  const addChild = useCallback(() => {
+    const nextChild: PerChildDraft = {
+      id: getNextChildId(state.children),
+      mode: 'charge',
+    };
+    persist({ ...state, children: [...state.children, nextChild] });
+  }, [state, persist]);
+
+  const updateChildMode = useCallback((childId: number, mode: PerChildDraft['mode']) => {
+    persist({
+      ...state,
+      children: state.children.map((child) => (
+        child.id === childId
+          ? { ...child, mode }
+          : child
+      )),
+    });
+  }, [state, persist]);
+
+  const removeChild = useCallback((childId: number) => {
+    persist({
+      ...state,
+      children: state.children.filter((child) => child.id !== childId),
+    });
   }, [state, persist]);
 
   const setVersementEnvisage = useCallback((v: number) => {
@@ -359,6 +429,9 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
     updateAvisIr,
     updateSituation,
     updateDeclarant,
+    addChild,
+    updateChildMode,
+    removeChild,
     setVersementEnvisage,
     nextStep,
     prevStep,

--- a/src/features/per/hooks/usePerPotentiel.ts
+++ b/src/features/per/hooks/usePerPotentiel.ts
@@ -183,7 +183,6 @@ function buildVisibleSteps(
 export interface UsePerPotentielReturn {
   state: PerPotentielState;
   result: PerPotentielResult | null;
-  baseResult: PerPotentielResult | null;
   visibleSteps: WizardStep[];
   setMode: (_mode: PerMode) => void;
   setHistoricalBasis: (_basis: PerHistoricalBasis) => void;
@@ -382,23 +381,6 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
     };
   }, [state, years.currentTaxYear, isCouple, fiscalContext]);
 
-  const baseResult = useMemo((): PerPotentielResult | null => {
-    if (state.step < 3) {
-      return null;
-    }
-
-    const input = buildInput(false);
-    if (!input) {
-      return null;
-    }
-
-    try {
-      return calculatePerPotentiel(input);
-    } catch {
-      return null;
-    }
-  }, [state.step, buildInput]);
-
   const result = useMemo((): PerPotentielResult | null => {
     if (state.step < 3) {
       return null;
@@ -421,7 +403,6 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
   return {
     state,
     result,
-    baseResult,
     visibleSteps,
     setMode,
     setHistoricalBasis,

--- a/src/features/per/styles/responsive.css
+++ b/src/features/per/styles/responsive.css
@@ -28,10 +28,6 @@
     grid-template-columns: 1fr;
   }
 
-  .per-avis-form-grid.is-couple {
-    grid-template-columns: 1fr;
-  }
-
   .per-situation-foyer-grid,
   .per-income-grid,
   .per-situation-kpis,
@@ -39,6 +35,12 @@
   .per-summary-stat-grid,
   .per-summary-simulation-grid {
     grid-template-columns: 1fr;
+  }
+
+  .per-avis-matrix-head-row,
+  .per-avis-matrix-row {
+    grid-template-columns: minmax(0, 1.45fr) 28px repeat(2, minmax(0, 0.82fr));
+    gap: 10px;
   }
 
   .per-potentiel-stage {
@@ -72,8 +74,51 @@
     grid-template-columns: 1fr;
   }
 
-  .per-avis-row {
+  .per-avis-matrix {
+    gap: 12px;
+  }
+
+  .per-avis-matrix-head-row {
+    display: none;
+  }
+
+  .per-avis-matrix-row {
     grid-template-columns: 1fr;
+    gap: 8px;
+    padding: 12px 14px;
+    border: 1px solid var(--color-c8);
+    border-radius: 10px;
+    background: var(--color-c7);
+  }
+
+  .per-avis-matrix-row--total {
+    background: color-mix(in srgb, var(--color-c4) 35%, #FFFFFF);
+  }
+
+  .per-avis-matrix-operator {
+    display: none;
+  }
+
+  .per-avis-matrix-cell,
+  .per-avis-matrix-total {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    align-items: center;
+    gap: 10px;
+  }
+
+  .per-avis-matrix-cell::before,
+  .per-avis-matrix-total::before {
+    content: attr(data-column-label);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: var(--color-c9);
+  }
+
+  .per-avis-matrix-total {
+    font-size: 16px;
   }
 
   .per-contribution-table,
@@ -112,14 +157,9 @@
     margin-bottom: 18px;
   }
 
-  .per-potentiel-stage-header,
   .per-potentiel-stage-footer {
     flex-direction: column;
     align-items: stretch;
-  }
-
-  .per-potentiel-stage-title {
-    font-size: 20px;
   }
 
   .per-summary-primary-value {

--- a/src/features/per/styles/responsive.css
+++ b/src/features/per/styles/responsive.css
@@ -38,6 +38,16 @@
     grid-template-columns: 1fr;
   }
 
+  .per-section-header-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .per-section-header-actions,
+  .per-income-filters {
+    justify-content: flex-start;
+  }
+
   .per-avis-matrix-head-row,
   .per-avis-matrix-row {
     grid-template-columns: minmax(0, 1.45fr) 28px repeat(2, minmax(0, 0.82fr));
@@ -63,6 +73,10 @@
   }
 
   .per-home-secondary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .per-potentiel-mini-kpis-row {
     grid-template-columns: 1fr;
   }
 
@@ -122,11 +136,6 @@
     font-size: 16px;
   }
 
-  .per-children-header {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
   .per-income-table,
   .per-income-table thead,
   .per-income-table tbody,
@@ -162,6 +171,10 @@
     font-weight: 600;
   }
 
+  .per-divider-row {
+    display: none;
+  }
+
   .per-income-table td[data-column-label] {
     display: grid;
     gap: 6px;
@@ -174,6 +187,14 @@
     letter-spacing: 0.8px;
     text-transform: uppercase;
     color: var(--color-c9);
+  }
+
+  .per-income-table-value-cell {
+    padding-top: 4px;
+  }
+
+  .per-income-table--single td:nth-child(3) {
+    display: none;
   }
 
   .per-contribution-table,

--- a/src/features/per/styles/responsive.css
+++ b/src/features/per/styles/responsive.css
@@ -20,20 +20,21 @@
   }
 
   .per-avis-layout,
-  .per-situation-top,
   .per-summary-top,
   .per-summary-columns,
-  .per-summary-breakdown-grid.is-couple,
-  .per-declarants-grid.is-couple {
+  .per-summary-breakdown-grid.is-couple {
     grid-template-columns: 1fr;
   }
 
   .per-situation-foyer-grid,
-  .per-income-grid,
-  .per-situation-kpis,
   .per-summary-hero-grid,
   .per-summary-stat-grid,
   .per-summary-simulation-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .per-child-row,
+  .per-income-real-cell {
     grid-template-columns: 1fr;
   }
 
@@ -119,6 +120,60 @@
 
   .per-avis-matrix-total {
     font-size: 16px;
+  }
+
+  .per-children-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .per-income-table,
+  .per-income-table thead,
+  .per-income-table tbody,
+  .per-income-table tr,
+  .per-income-table th,
+  .per-income-table td {
+    display: block;
+  }
+
+  .per-income-table thead {
+    display: none;
+  }
+
+  .per-income-table tr {
+    padding: 12px 14px;
+    border: 1px solid var(--color-c8);
+    border-radius: 10px;
+    background: #FFFFFF;
+  }
+
+  .per-income-table tbody {
+    display: grid;
+    gap: 12px;
+  }
+
+  .per-income-table td {
+    padding: 0;
+    border-bottom: none;
+  }
+
+  .per-income-table td:first-child {
+    padding-bottom: 8px;
+    font-weight: 600;
+  }
+
+  .per-income-table td[data-column-label] {
+    display: grid;
+    gap: 6px;
+  }
+
+  .per-income-table td[data-column-label]::before {
+    content: attr(data-column-label);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    color: var(--color-c9);
   }
 
   .per-contribution-table,

--- a/src/features/per/styles/responsive.css
+++ b/src/features/per/styles/responsive.css
@@ -89,6 +89,10 @@
     grid-template-columns: 1fr;
   }
 
+  .per-children-list {
+    grid-template-columns: 1fr;
+  }
+
   .per-avis-matrix {
     gap: 12px;
   }

--- a/src/features/per/styles/steps.css
+++ b/src/features/per/styles/steps.css
@@ -304,14 +304,38 @@
   box-sizing: border-box;
 }
 
+.per-situation-card.premium-card--guide,
+.per-income-table-card.premium-card--guide {
+  overflow: visible;
+}
+
+.per-situation-card .sim-divider,
+.per-income-table-card .sim-divider {
+  margin: 14px 0 18px;
+}
+
+.per-situation-card .sim-card__icon,
+.per-income-table-card .sim-card__icon {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-c4);
+  border-radius: 6px;
+  color: var(--color-c2);
+  flex-shrink: 0;
+}
+
 .per-section-header {
   display: grid;
-  gap: 10px;
+  gap: 6px;
+  margin-bottom: 10px;
 }
 
 .per-section-header-row {
   display: flex;
-  align-items: flex-start;
+  align-items: stretch;
   justify-content: space-between;
   gap: 12px;
 }
@@ -323,8 +347,9 @@
 }
 
 .per-section-title-block {
-  display: grid;
-  gap: 2px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .per-section-title-block .premium-section-title {
@@ -333,85 +358,103 @@
 
 .per-section-title-block .sim-card__title {
   margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-c1);
 }
 
 .per-section-subtitle {
   margin: 0;
   font-size: 12px;
-  line-height: 1.6;
+  line-height: 1.45;
   color: var(--color-c9);
 }
 
 .per-situation-foyer-grid {
   display: grid;
-  grid-template-columns: minmax(280px, 0.95fr) minmax(0, 1.05fr);
+  grid-template-columns: 1fr 1fr;
   gap: 16px;
   align-items: start;
 }
 
+.per-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+}
+
+.per-field label {
+  color: var(--color-c9);
+}
+
 .per-children-zone {
-  display: grid;
-  gap: 12px;
-}
-
-.per-child-add-btn,
-.per-child-remove-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  border: 1px solid var(--color-c8);
-  border-radius: 10px;
-  background: #FFFFFF;
-  color: var(--color-c1);
-  cursor: pointer;
-  transition: border-color 0.2s, transform 0.2s;
-}
-
-.per-child-add-btn {
-  padding: 10px 12px;
-  font-size: 12px;
-  font-weight: 600;
-  justify-self: flex-start;
-}
-
-.per-child-remove-btn {
-  width: 38px;
-  height: 38px;
-  padding: 0;
-}
-
-.per-child-add-btn:hover,
-.per-child-remove-btn:hover {
-  border-color: var(--color-c3);
-  transform: translateY(-1px);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .per-children-list {
   display: grid;
-  gap: 10px;
+  grid-template-columns: 1fr 1fr;
+  gap: 5px 8px;
+}
+
+.per-child-add-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 0;
+  border: none;
+  background: none;
+  font-size: 12px;
+  color: var(--color-c2);
+  cursor: pointer;
+  font-family: inherit;
+  transition: color 0.15s;
+  justify-self: flex-start;
+}
+
+.per-child-remove-btn {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  padding: 2px;
+  border: none;
+  border-radius: 3px;
+  background: none;
+  color: var(--color-c9);
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.per-child-add-btn:hover,
+.per-child-remove-btn:hover {
+  color: var(--color-c1);
+}
+
+.per-child-add-btn:focus-visible,
+.per-child-remove-btn:focus-visible {
+  outline: 2px solid var(--color-c2);
+  outline-offset: 2px;
 }
 
 .per-child-row {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  gap: 10px;
+  display: flex;
   align-items: center;
-  padding: 10px 12px;
-  border: 1px solid var(--color-c8);
-  border-radius: 10px;
-  background: var(--color-c7);
+  gap: 6px;
+  font-size: 13px;
 }
 
 .per-child-row__label {
-  min-width: 28px;
   font-size: 12px;
-  font-weight: 700;
   color: var(--color-c9);
+  white-space: nowrap;
+  min-width: 24px;
 }
 
 .per-child-row__select {
-  width: 100%;
+  flex: 1;
 }
 
 .per-income-table-wrap {
@@ -461,27 +504,25 @@
 .per-income-table {
   width: 100%;
   border-collapse: collapse;
-  table-layout: fixed;
+  font-size: 13px;
+}
+
+.per-income-table thead {
+  background: transparent;
 }
 
 .per-income-table th,
 .per-income-table td {
-  padding: 12px 14px;
-  border-bottom: 1px solid var(--color-c8);
-  vertical-align: top;
+  padding: 6px 8px;
 }
 
 .per-income-table thead th {
-  background: var(--color-c7);
-  font-size: 11px;
   font-weight: 600;
-  letter-spacing: 0.8px;
-  text-transform: uppercase;
-  color: var(--color-c9);
+  color: var(--color-c1);
 }
 
 .per-income-table thead th:first-child {
-  text-align: left;
+  text-align: center;
 }
 
 .per-income-table thead th:not(:first-child) {
@@ -490,6 +531,7 @@
 
 .per-income-table tbody td:first-child {
   color: var(--color-c10);
+  font-weight: 500;
 }
 
 .per-income-table--single th:nth-child(3),
@@ -509,15 +551,16 @@
 }
 
 .per-income-table-row-title td {
-  background: color-mix(in srgb, var(--color-c7) 65%, #FFFFFF);
-}
-
-.per-income-table-row-title td:first-child {
+  background: transparent;
   font-weight: 600;
 }
 
+.per-income-table-row-title td:first-child {
+  color: var(--color-c9);
+}
+
 .per-income-table-value-cell {
-  padding: 12px 14px;
+  padding: 6px 8px;
   font-size: 13px;
   font-weight: 600;
   color: var(--color-c1);
@@ -534,23 +577,63 @@
   font-variant-numeric: tabular-nums;
 }
 
-.per-income-table-input--readonly {
-  background: var(--color-c7);
+.per-table-input {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  width: 100%;
 }
 
-.per-income-real-cell {
-  display: grid;
-  grid-template-columns: minmax(82px, 92px) minmax(0, 1fr);
-  gap: 10px;
-  align-items: start;
+.per-table-input__row {
+  width: 100%;
 }
 
-.per-income-real-select {
+.per-table-input input[type='text'],
+.per-table-input input[type='number'] {
+  flex: 1 1 auto;
   min-width: 0;
 }
 
+.per-table-input__unit {
+  min-width: 14px;
+  margin-left: 6px;
+  color: var(--color-c9);
+  font-size: 13px;
+  line-height: 1;
+  text-align: right;
+}
+
+.per-table-input__control--readonly,
+.per-income-table-input--readonly {
+  background: #FFFFFF;
+}
+
+.per-income-real-cell {
+  display: flex;
+  gap: 4px;
+}
+
+.per-income-real-select {
+  flex: 1;
+}
+
 .per-contribution-toggle {
-  margin-bottom: 14px;
+  margin-top: 14px;
+}
+
+.per-checkbox {
+  accent-color: var(--color-c2);
+  cursor: pointer;
+}
+
+.per-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--color-c9);
+  cursor: pointer;
 }
 
 .per-contribution-table {
@@ -587,6 +670,8 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+  font-size: 13px;
+  font-weight: 500;
   color: var(--color-c10);
 }
 

--- a/src/features/per/styles/steps.css
+++ b/src/features/per/styles/steps.css
@@ -293,35 +293,40 @@
   margin-top: 2px;
 }
 
-.per-situation-top {
+.per-step--situation {
   display: grid;
-  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
   gap: 16px;
 }
 
-.per-situation-top--single {
-  grid-template-columns: 1fr;
-}
-
-.per-situation-card {
+.per-situation-card,
+.per-income-table-card,
+.per-contribution-card {
   box-sizing: border-box;
 }
 
-.per-situation-card--accent {
-  border-left: 3px solid var(--color-c3);
+.per-section-header {
+  display: grid;
+  gap: 10px;
 }
 
-.per-situation-card-header,
-.per-income-card-header {
-  margin-bottom: 16px;
+.per-section-title-block {
+  display: grid;
+  gap: 2px;
 }
 
-.per-situation-card-title,
-.per-income-card-title {
+.per-section-title-block .premium-section-title {
   margin: 0;
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--color-c1);
+}
+
+.per-section-title-block .sim-card__title {
+  margin: 0;
+}
+
+.per-section-subtitle {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--color-c9);
 }
 
 .per-situation-foyer-grid {
@@ -331,21 +336,16 @@
   align-items: start;
 }
 
-.per-situation-kpis {
+.per-parts-summary {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-}
-
-.per-situation-kpi {
-  padding: 14px;
+  gap: 6px;
+  padding: 12px 14px;
+  border: 1px solid var(--color-c8);
   border-radius: 10px;
   background: var(--color-c7);
 }
 
-.per-situation-kpi-label {
-  display: block;
-  margin-bottom: 6px;
+.per-parts-summary__label {
   font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.8px;
@@ -353,10 +353,90 @@
   color: var(--color-c9);
 }
 
-.per-situation-kpi-value {
-  font-size: 20px;
+.per-parts-summary__value {
+  font-size: 22px;
   font-weight: 700;
   color: var(--color-c1);
+  font-variant-numeric: tabular-nums;
+}
+
+.per-children-zone {
+  display: grid;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.per-children-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.per-children-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-c1);
+}
+
+.per-child-add-btn,
+.per-child-remove-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 1px solid var(--color-c8);
+  border-radius: 10px;
+  background: #FFFFFF;
+  color: var(--color-c1);
+  cursor: pointer;
+  transition: border-color 0.2s, transform 0.2s;
+}
+
+.per-child-add-btn {
+  padding: 10px 12px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.per-child-remove-btn {
+  width: 38px;
+  height: 38px;
+  padding: 0;
+}
+
+.per-child-add-btn:hover,
+.per-child-remove-btn:hover {
+  border-color: var(--color-c3);
+  transform: translateY(-1px);
+}
+
+.per-children-list {
+  display: grid;
+  gap: 10px;
+}
+
+.per-child-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 12px;
+  border: 1px solid var(--color-c8);
+  border-radius: 10px;
+  background: var(--color-c7);
+}
+
+.per-child-row__label {
+  min-width: 28px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-c9);
+}
+
+.per-child-row__select {
+  width: 100%;
 }
 
 .per-situation-note {
@@ -366,13 +446,79 @@
   color: var(--color-c9);
 }
 
-.per-situation-income-copy {
-  display: grid;
-  gap: 6px;
+.per-income-table-wrap {
+  width: 100%;
 }
 
-.per-contribution-card {
-  box-sizing: border-box;
+.per-income-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.per-income-table th,
+.per-income-table td {
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--color-c8);
+  vertical-align: top;
+}
+
+.per-income-table thead th {
+  background: var(--color-c7);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: var(--color-c9);
+}
+
+.per-income-table thead th:first-child {
+  text-align: left;
+}
+
+.per-income-table thead th:not(:first-child) {
+  text-align: center;
+}
+
+.per-income-table tbody td:first-child {
+  color: var(--color-c10);
+}
+
+.per-income-table-row-title td {
+  background: color-mix(in srgb, var(--color-c7) 65%, #FFFFFF);
+}
+
+.per-income-table-row-title td:first-child {
+  font-weight: 600;
+}
+
+.per-income-table-input,
+.per-contribution-input {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.per-income-real-cell {
+  display: grid;
+  grid-template-columns: minmax(82px, 92px) minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+}
+
+.per-income-real-select {
+  min-width: 0;
+}
+
+.per-income-readonly {
+  display: flex;
+  min-height: 42px;
+  align-items: center;
+  padding: 0 12px;
+  border: 1px solid var(--color-c8);
+  border-radius: 10px;
+  background: var(--color-c7);
+  font-size: 12px;
+  color: var(--color-c9);
 }
 
 .per-contribution-table {
@@ -430,35 +576,5 @@
   letter-spacing: 0.8px;
   text-transform: uppercase;
   color: var(--color-c9);
-}
-
-.per-declarants-grid {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 16px;
-}
-
-.per-declarants-grid.is-couple {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.per-income-card {
-  box-sizing: border-box;
-}
-
-.per-income-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 14px;
-}
-
-.per-income-toggle-row {
-  display: grid;
-  gap: 14px;
-  margin-top: 18px;
-}
-
-.per-income-toggle-field {
-  max-width: 280px;
 }
 

--- a/src/features/per/styles/steps.css
+++ b/src/features/per/styles/steps.css
@@ -309,6 +309,19 @@
   gap: 10px;
 }
 
+.per-section-header-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.per-section-header-actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 .per-section-title-block {
   display: grid;
   gap: 2px;
@@ -331,53 +344,14 @@
 
 .per-situation-foyer-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 14px;
+  grid-template-columns: minmax(280px, 0.95fr) minmax(0, 1.05fr);
+  gap: 16px;
   align-items: start;
-}
-
-.per-parts-summary {
-  display: grid;
-  gap: 6px;
-  padding: 12px 14px;
-  border: 1px solid var(--color-c8);
-  border-radius: 10px;
-  background: var(--color-c7);
-}
-
-.per-parts-summary__label {
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.8px;
-  text-transform: uppercase;
-  color: var(--color-c9);
-}
-
-.per-parts-summary__value {
-  font-size: 22px;
-  font-weight: 700;
-  color: var(--color-c1);
-  font-variant-numeric: tabular-nums;
 }
 
 .per-children-zone {
   display: grid;
   gap: 12px;
-  margin-top: 16px;
-}
-
-.per-children-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.per-children-title {
-  margin: 0;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--color-c1);
 }
 
 .per-child-add-btn,
@@ -398,6 +372,7 @@
   padding: 10px 12px;
   font-size: 12px;
   font-weight: 600;
+  justify-self: flex-start;
 }
 
 .per-child-remove-btn {
@@ -439,15 +414,48 @@
   width: 100%;
 }
 
-.per-situation-note {
-  margin: 0;
-  font-size: 13px;
-  line-height: 1.6;
-  color: var(--color-c9);
-}
-
 .per-income-table-wrap {
   width: 100%;
+}
+
+.per-income-filters {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.per-income-filter-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  padding: 4px 10px;
+  border: 1px solid var(--color-c8);
+  border-radius: 999px;
+  background: var(--color-c7);
+  color: var(--color-c9);
+  font-size: 12px;
+  line-height: 1;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s, background-color 0.2s;
+}
+
+.per-income-filter-btn:hover {
+  border-color: var(--color-c3);
+  color: var(--color-c1);
+}
+
+.per-income-filter-btn.is-active {
+  background: color-mix(in srgb, var(--color-c3) 22%, #FFFFFF);
+  border-color: color-mix(in srgb, var(--color-c3) 55%, var(--color-c8));
+  color: var(--color-c1);
+}
+
+.per-income-filter-btn:focus-visible {
+  outline: 2px solid var(--color-c2);
+  outline-offset: 1px;
 }
 
 .per-income-table {
@@ -484,6 +492,22 @@
   color: var(--color-c10);
 }
 
+.per-income-table--single th:nth-child(3),
+.per-income-table--single td:nth-child(3) {
+  display: none;
+}
+
+.per-divider-row td {
+  padding: 0;
+  border-bottom: none;
+}
+
+.per-divider-row__inner {
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--color-c8), transparent);
+  margin: 4px 8px;
+}
+
 .per-income-table-row-title td {
   background: color-mix(in srgb, var(--color-c7) 65%, #FFFFFF);
 }
@@ -492,10 +516,26 @@
   font-weight: 600;
 }
 
+.per-income-table-value-cell {
+  padding: 12px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-c1);
+  font-variant-numeric: tabular-nums;
+}
+
+.per-income-table-value-cell--center {
+  text-align: center;
+}
+
 .per-income-table-input,
 .per-contribution-input {
   text-align: right;
   font-variant-numeric: tabular-nums;
+}
+
+.per-income-table-input--readonly {
+  background: var(--color-c7);
 }
 
 .per-income-real-cell {
@@ -509,16 +549,8 @@
   min-width: 0;
 }
 
-.per-income-readonly {
-  display: flex;
-  min-height: 42px;
-  align-items: center;
-  padding: 0 12px;
-  border: 1px solid var(--color-c8);
-  border-radius: 10px;
-  background: var(--color-c7);
-  font-size: 12px;
-  color: var(--color-c9);
+.per-contribution-toggle {
+  margin-bottom: 14px;
 }
 
 .per-contribution-table {

--- a/src/features/per/styles/steps.css
+++ b/src/features/per/styles/steps.css
@@ -185,73 +185,112 @@
 }
 
 
-.per-avis-form-grid {
+.per-avis-intro {
   display: grid;
-  grid-template-columns: 1fr;
-  gap: 16px;
+  gap: 6px;
+  margin-bottom: 18px;
 }
 
-.per-avis-form-grid--always-two {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.per-avis-form-card {
-  box-sizing: border-box;
-}
-
-.per-avis-form-header {
-  margin-bottom: 0;
-}
-
-/* Ligne totale plafond */
-.per-avis-total-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 12px 0;
-  border-top: 1px solid var(--color-c8);
-  margin-top: 4px;
-  font-weight: 600;
-  font-size: 14px;
-  color: var(--color-c1);
-}
-
-.per-avis-total-label {
-  color: var(--color-c1);
-}
-
-.per-avis-total-value {
-  font-variant-numeric: tabular-nums;
-}
-
-.per-avis-form-title {
+.per-avis-copy {
+  max-width: 760px;
   margin: 0;
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--color-c1);
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--color-c9);
 }
 
-.per-avis-row-list {
+.per-avis-matrix {
   display: grid;
+  gap: 10px;
+}
+
+.per-avis-matrix-head-row,
+.per-avis-matrix-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.7fr) 32px repeat(2, minmax(0, 0.78fr));
   gap: 12px;
-}
-
-.per-avis-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 170px;
-  gap: 16px;
   align-items: center;
 }
 
-.per-avis-row-label {
+.per-avis-matrix-head-row {
+  padding: 0 0 8px;
+  border-bottom: 1px solid var(--color-c8);
+}
+
+.per-avis-matrix-head {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: var(--color-c9);
+}
+
+.per-avis-matrix-head--label {
+  color: var(--color-c9);
+}
+
+.per-avis-matrix-head:not(.per-avis-matrix-head--label) {
+  justify-content: center;
+  text-align: center;
+}
+
+.per-avis-matrix-head--operator {
+  justify-content: center;
+}
+
+.per-avis-matrix-row {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--color-c8);
+}
+
+.per-avis-matrix-row--total {
+  padding-top: 14px;
+  border-bottom: none;
+}
+
+.per-avis-matrix-label {
   font-size: 13px;
   line-height: 1.5;
   color: var(--color-c10);
 }
 
-.per-avis-row-input {
+.per-avis-matrix-label--total {
+  font-weight: 600;
+  color: var(--color-c1);
+}
+
+.per-avis-matrix-operator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--color-c5);
+}
+
+.per-avis-matrix-operator--total {
+  color: var(--color-c1);
+}
+
+.per-avis-matrix-cell {
+  min-width: 0;
+}
+
+.per-avis-matrix-input {
   width: 100%;
   box-sizing: border-box;
+}
+
+.per-avis-matrix-total {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--color-c1);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.per-avis-sidebar-kpis {
+  margin-top: 2px;
 }
 
 .per-situation-top {

--- a/src/features/per/styles/wizard.css
+++ b/src/features/per/styles/wizard.css
@@ -222,6 +222,12 @@
   gap: 12px;
 }
 
+.per-potentiel-mini-kpis-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
 .per-potentiel-mini-kpi {
   display: flex;
   flex-direction: column;

--- a/src/features/per/styles/wizard.css
+++ b/src/features/per/styles/wizard.css
@@ -89,20 +89,13 @@
 }
 
 .per-potentiel-stage-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 20px;
-  padding-bottom: 18px;
-  border-bottom: 1px solid var(--color-c8);
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: none;
 }
 
-.per-potentiel-stage-title {
-  margin: 0 0 8px;
-  font-size: 24px;
-  font-weight: 600;
-  color: var(--color-c1);
+.per-potentiel-stage-divider {
+  margin: 12px 0 18px;
 }
 
 .per-potentiel-stage-desc {

--- a/src/features/per/utils/perParts.test.ts
+++ b/src/features/per/utils/perParts.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { derivePerNombreParts } from './perParts';
+
+describe('derivePerNombreParts', () => {
+  it('calcule les parts pour un couple avec deux enfants à charge', () => {
+    expect(
+      derivePerNombreParts({
+        situationFamiliale: 'marie',
+        isole: false,
+        children: [
+          { id: 1, mode: 'charge' },
+          { id: 2, mode: 'charge' },
+        ],
+      }),
+    ).toBe(3);
+  });
+
+  it('ajoute la majoration parent isolé pour un célibataire avec un enfant à charge', () => {
+    expect(
+      derivePerNombreParts({
+        situationFamiliale: 'celibataire',
+        isole: true,
+        children: [{ id: 1, mode: 'charge' }],
+      }),
+    ).toBe(2);
+  });
+
+  it('calcule les quarts de part en garde alternée', () => {
+    expect(
+      derivePerNombreParts({
+        situationFamiliale: 'celibataire',
+        isole: false,
+        children: [{ id: 1, mode: 'shared' }],
+      }),
+    ).toBe(1.25);
+  });
+});

--- a/src/features/per/utils/perParts.ts
+++ b/src/features/per/utils/perParts.ts
@@ -1,0 +1,25 @@
+import { computeAutoPartsWithChildren } from '../../../engine/ir/parts';
+import type { IrChild } from '../../../engine/ir/types';
+
+export interface PerChildDraft {
+  id: number;
+  mode: 'charge' | 'shared';
+}
+
+export function derivePerNombreParts({
+  situationFamiliale,
+  isole,
+  children,
+}: {
+  situationFamiliale: 'celibataire' | 'marie';
+  isole: boolean;
+  children: PerChildDraft[];
+}): number {
+  const irChildren: IrChild[] = children.map((child) => ({ mode: child.mode }));
+
+  return computeAutoPartsWithChildren({
+    status: situationFamiliale === 'marie' ? 'couple' : 'single',
+    isIsolated: isole,
+    children: irChildren,
+  });
+}


### PR DESCRIPTION
## Description
Corrections visuelles et fonctionnelles du bloc « Versements retraite » sur `/sim/per/potentiel` : alignement typographique, repositionnement de la case mutualisation et filtrage conditionnel des lignes TNS.

## Changements
- `src/features/per/components/potentiel/steps/SituationFiscaleStep.tsx` — tnsOnly sur 3 lignes, déplacement mutualisation, SimSelect pour les selects du foyer
- `src/features/per/styles/steps.css` — font-size/font-weight sur `.per-contribution-table-label`, margin-top sur `.per-contribution-toggle`
- `src/features/per/styles/responsive.css` — liste enfants en colonne unique sous 900 px
- `src/features/per/components/potentiel/steps/PerIncomeTable.tsx` — alignements et nettoyages associés

## Fonctionnalités
- Les libellés « PER 163 quatervicies », « PERP et assimilés », etc. ont désormais la même taille et graisse (13 px / 500) que les lignes du tableau des revenus
- La case « Mutualisation des plafonds (case 6QR) » s'affiche **sous** le tableau plutôt qu'au-dessus
- Les lignes « PER 154 bis », « Madelin retraite » et « Prévoyance Madelin » n'apparaissent que si le filtre **TNS** est activé dans le bloc « Revenus imposables »

## Tests effectués
- [x] `npm run lint` passe
- [x] `npm run typecheck` passe
- [x] `npm test` passe
- [x] `npm run build` — à vérifier en CI
- [x] `npm run check` passe sur tous les checks statiques (lint, typecheck, fiscal-hardcode, css-colors, arch, circular…)

## Notes
Les échecs `npm test` (93 × « No test suite found ») sont pré-existants sur cette branche et non introduits par ce commit — vérifiable via `git stash && npm test`.

## Checklist
- [x] Pas de push direct sur `main`
- [x] Pas de fichiers temporaires ajoutés à la racine
- [x] Documentation mise à jour si nécessaire