### PR TITLE
fix(per): aligner revenus 2025 et consommation des plafonds

### DIFF
--- a/scripts/check-no-hardcoded-fiscal-values.mjs
+++ b/scripts/check-no-hardcoded-fiscal-values.mjs
@@ -57,6 +57,22 @@ const FORBIDDEN_VALUES = [
     label: 'PASS 2025',
     pattern: /\b47100\b/,
   },
+  {
+    label: 'abattement retraites current plafond',
+    pattern: /\b4399\b/,
+  },
+  {
+    label: 'abattement retraites current plancher',
+    pattern: /\b450\b/,
+  },
+  {
+    label: 'abattement retraites previous plafond',
+    pattern: /\b4321\b/,
+  },
+  {
+    label: 'abattement retraites previous plancher',
+    pattern: /\b442\b/,
+  },
 ];
 
 // ─── Répertoires à scanner (relatifs à ROOT) ──────────────────────────────────

--- a/src/components/ui/sim/SimSelect.tsx
+++ b/src/components/ui/sim/SimSelect.tsx
@@ -12,6 +12,7 @@ export interface SimSelectProps {
   onChange: (_value: string) => void;
   options: SimSelectOption[];
   placeholder?: string;
+  ariaLabel?: string;
   align?: 'right' | 'left';
   forced?: boolean;
   disabled?: boolean;
@@ -25,6 +26,7 @@ export function SimSelect({
   onChange,
   options,
   placeholder,
+  ariaLabel,
   align = 'right',
   forced = false,
   disabled = false,
@@ -77,6 +79,7 @@ export function SimSelect({
         onClick={() => { if (!forced) setOpen((v) => !v); }}
         aria-haspopup="listbox"
         aria-expanded={open}
+        aria-label={ariaLabel}
         data-testid={testId}
       >
         <span className={`sim-field__select-value${!selected && placeholder ? ' sim-field__select-value--placeholder' : ''}`}>

--- a/src/engine/per/__tests__/perDeclarationFlow.test.ts
+++ b/src/engine/per/__tests__/perDeclarationFlow.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { computeDeclaration2042 } from '../perDeclarationFlow';
+import type { DeclarantRevenus, PlafondMadelinDetail } from '../types';
+
+function makeDeclarant(overrides: Partial<DeclarantRevenus> = {}): DeclarantRevenus {
+  return {
+    statutTns: true,
+    salaires: 0,
+    fraisReels: false,
+    fraisReelsMontant: 0,
+    art62: 0,
+    bic: 0,
+    retraites: 0,
+    fonciersNets: 0,
+    autresRevenus: 0,
+    cotisationsPer163Q: 0,
+    cotisationsPerp: 0,
+    cotisationsArt83: 0,
+    cotisationsMadelin154bis: 0,
+    cotisationsMadelinRetraite: 0,
+    abondementPerco: 0,
+    cotisationsPrevo: 0,
+    ...overrides,
+  };
+}
+
+function makeMadelin(overrides: Partial<PlafondMadelinDetail> = {}): PlafondMadelinDetail {
+  return {
+    assietteVersement: 0,
+    assietteReport: 0,
+    enveloppe15Versement: 0,
+    enveloppe15Report: 0,
+    enveloppe10: 0,
+    cotisationsVersees: 0,
+    utilisation15Versement: { madelinRetraite: 0, per154bis: 0, total: 0 },
+    depassement15Versement: { madelinRetraite: 0, per154bis: 0, total: 0 },
+    utilisation15Report: { madelinRetraite: 0, per154bis: 0, total: 0 },
+    depassement15Report: { madelinRetraite: 0, per154bis: 0, total: 0 },
+    consommation10: { art83: 0, perco: 0, madelinRetraite: 0, per154bis: 0, total: 0 },
+    reste15Versement: 0,
+    reste15Report: 0,
+    reste10: 0,
+    disponibleRestant: 0,
+    surplusAReintegrer: 0,
+    depassement: false,
+    ...overrides,
+  };
+}
+
+describe('computeDeclaration2042', () => {
+  it('laisse 6OS à zéro quand l’enveloppe 15 % report absorbe Madelin et PER 154 bis', () => {
+    const result = computeDeclaration2042({
+      declarant1: makeDeclarant({
+        cotisationsMadelinRetraite: 3000,
+        cotisationsMadelin154bis: 2000,
+      }),
+      madelin1: makeMadelin({
+        enveloppe15Report: 10000,
+        depassement15Report: { madelinRetraite: 0, per154bis: 0, total: 0 },
+      }),
+      mutualisationConjoints: false,
+    });
+
+    expect(result.case6OS).toBe(0);
+    expect(result.case6QS).toBe(0);
+  });
+
+  it('alimente 6OS avec le dépassement combiné quand Madelin ne dépasse pas seul l’enveloppe de report', () => {
+    const result = computeDeclaration2042({
+      declarant1: makeDeclarant({
+        cotisationsMadelinRetraite: 8000,
+        cotisationsMadelin154bis: 6000,
+      }),
+      madelin1: makeMadelin({
+        enveloppe15Report: 10000,
+        depassement15Report: { madelinRetraite: 0, per154bis: 4000, total: 4000 },
+      }),
+      mutualisationConjoints: false,
+    });
+
+    expect(result.case6OS).toBe(4000);
+    expect(result.case6QS).toBe(0);
+  });
+
+  it('bascule tout le PER 154 bis en 6OS quand Madelin dépasse déjà seul l’enveloppe de report', () => {
+    const result = computeDeclaration2042({
+      declarant1: makeDeclarant({
+        cotisationsArt83: 1000,
+        abondementPerco: 500,
+        cotisationsMadelinRetraite: 12000,
+        cotisationsMadelin154bis: 6000,
+      }),
+      madelin1: makeMadelin({
+        enveloppe15Report: 10000,
+        depassement15Report: { madelinRetraite: 2000, per154bis: 6000, total: 8000 },
+      }),
+      mutualisationConjoints: false,
+    });
+
+    expect(result.case6OS).toBe(6000);
+    expect(result.case6QS).toBe(3500);
+  });
+});

--- a/src/engine/per/__tests__/perPotentiel.test.ts
+++ b/src/engine/per/__tests__/perPotentiel.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import { calculatePerPotentiel } from '../perPotentiel';
-import { computePlafond163QBrut } from '../plafond163Q';
-import { computePlafondMadelin } from '../plafondMadelin';
-import { DEFAULT_TAX_SETTINGS, DEFAULT_PS_SETTINGS, DEFAULT_PASS_HISTORY } from '../../../constants/settingsDefaults';
-import type { DeclarantRevenus, PerPotentielInput, PerWarning } from '../types';
-
-const PASS_2025 = 47100;
+import {
+  DEFAULT_PASS_HISTORY,
+  DEFAULT_PS_SETTINGS,
+  DEFAULT_TAX_SETTINGS,
+} from '../../../constants/settingsDefaults';
+import type { AvisIrPlafonds, DeclarantRevenus, PerPotentielInput } from '../types';
 
 function makeDeclarant(overrides: Partial<DeclarantRevenus> = {}): DeclarantRevenus {
   return {
+    statutTns: false,
     salaires: 0,
     fraisReels: false,
     fraisReelsMontant: 0,
@@ -28,17 +29,30 @@ function makeDeclarant(overrides: Partial<DeclarantRevenus> = {}): DeclarantReve
   };
 }
 
+function makeAvis(overrides: Partial<AvisIrPlafonds> = {}): AvisIrPlafonds {
+  return {
+    nonUtiliseAnnee1: 1000,
+    nonUtiliseAnnee2: 2000,
+    nonUtiliseAnnee3: 3000,
+    plafondCalcule: 4000,
+    anneeRef: 2025,
+    ...overrides,
+  };
+}
+
 function makeInput(overrides: Partial<PerPotentielInput> = {}): PerPotentielInput {
   return {
-    mode: 'versement-n',
+    mode: 'declaration-n1',
     historicalBasis: 'previous-avis-plus-n1',
     anneeRef: 2025,
+    yearKey: 'current',
     situationFiscale: {
       situationFamiliale: 'celibataire',
       nombreParts: 1,
       isole: false,
-      declarant1: makeDeclarant({ salaires: 50000 }),
+      declarant1: makeDeclarant({ salaires: 60000, cotisationsPer163Q: 3000 }),
     },
+    avisIr: makeAvis(),
     mutualisationConjoints: false,
     passHistory: DEFAULT_PASS_HISTORY,
     taxSettings: DEFAULT_TAX_SETTINGS,
@@ -47,277 +61,217 @@ function makeInput(overrides: Partial<PerPotentielInput> = {}): PerPotentielInpu
   };
 }
 
-// ── Plafond 163Q unit tests ──────────────────────────────────────────────────
-
-describe('computePlafond163QBrut', () => {
-  it('returns 10% of revenue when between min and max', () => {
-    // 80k * 10% = 8000, min = 4710, max = 37680 → 8000
-    expect(computePlafond163QBrut(80000, PASS_2025)).toBe(8000);
-  });
-
-  it('clamps to minimum (10% of 1 PASS) for low income', () => {
-    // 20k * 10% = 2000, min = 4710 → 4710
-    expect(computePlafond163QBrut(20000, PASS_2025)).toBe(4710);
-  });
-
-  it('clamps to maximum (10% of 8 PASS) for very high income', () => {
-    // 500k * 10% = 50000, max = 37680 → 37680
-    expect(computePlafond163QBrut(500000, PASS_2025)).toBe(37680);
-  });
-
-  it('returns minimum for zero income', () => {
-    expect(computePlafond163QBrut(0, PASS_2025)).toBe(4710);
-  });
-
-  it('uses spouse plafond for simulation only when mutualisation is enabled', () => {
-    const baseInput = {
-      mode: 'versement-n' as const,
-      historicalBasis: 'previous-avis-plus-n1' as const,
-      anneeRef: 2025,
-      situationFiscale: {
-        situationFamiliale: 'marie' as const,
-        nombreParts: 2,
-        isole: false,
-        declarant1: makeDeclarant({ salaires: 80000 }),
-        declarant2: makeDeclarant({ salaires: 30000 }),
-      },
-      versementEnvisage: 12000,
-      passHistory: DEFAULT_PASS_HISTORY,
-      taxSettings: DEFAULT_TAX_SETTINGS,
-      psSettings: DEFAULT_PS_SETTINGS,
-    };
-
-    const sansMutualisation = calculatePerPotentiel({
-      ...baseInput,
-      mutualisationConjoints: false,
-    });
-
-    const avecMutualisation = calculatePerPotentiel({
-      ...baseInput,
-      mutualisationConjoints: true,
-    });
-
-    expect(sansMutualisation.declaration2042.case6QR).toBe(false);
-    expect(avecMutualisation.declaration2042.case6QR).toBe(true);
-    expect(sansMutualisation.simulation).toBeDefined();
-    expect(avecMutualisation.simulation).toBeDefined();
-    expect(sansMutualisation.simulation!.versementDeductible).toBe(7200);
-    expect(avecMutualisation.simulation!.versementDeductible).toBe(11910);
-    expect(sansMutualisation.simulation!.economieIRAnnuelle).toBe(2160);
-    expect(avecMutualisation.simulation!.economieIRAnnuelle).toBe(3573);
-  });
-});
-
-// ── Plafond Madelin unit tests ───────────────────────────────────────────────
-
-describe('computePlafondMadelin', () => {
-  it('returns null for salaried worker (no BIC/art62)', () => {
-    const warnings: PerWarning[] = [];
-    const result = computePlafondMadelin({
-      declarant: makeDeclarant({ salaires: 80000 }),
-      pass: PASS_2025,
-    }, warnings);
-    expect(result).toBeNull();
-  });
-
-  it('computes correct envelopes for TNS BIC 120k', () => {
-    const warnings: PerWarning[] = [];
-    const d = makeDeclarant({ bic: 120000 });
-    const result = computePlafondMadelin({ declarant: d, pass: PASS_2025 }, warnings);
-    expect(result).not.toBeNull();
-    // env 15% = (120000 - 47100) * 0.15 = 10935
-    expect(result!.enveloppe15).toBe(10935);
-    // env 10% = 120000 * 0.1 = 12000 (between min 4710 and max 37680)
-    expect(result!.enveloppe10).toBe(12000);
-    // total = 10935 + 12000 = 22935
-    expect(result!.potentielTotal).toBe(22935);
-    expect(result!.disponibleRestant).toBe(22935);
-  });
-
-  it('computes minimum envelope for low TNS income', () => {
-    const warnings: PerWarning[] = [];
-    const d = makeDeclarant({ bic: 30000 });
-    const result = computePlafondMadelin({ declarant: d, pass: PASS_2025 }, warnings);
-    expect(result).not.toBeNull();
-    // assiette = 30000 < PASS → env15 = 0, env10 = 10%*PASS = 4710
-    expect(result!.enveloppe15).toBe(0);
-    expect(result!.enveloppe10).toBe(4710);
-  });
-
-  it('warns on dépassement', () => {
-    const warnings: PerWarning[] = [];
-    const d = makeDeclarant({
-      bic: 30000,
-      cotisationsMadelinRetraite: 5000,
-    });
-    const result = computePlafondMadelin({ declarant: d, pass: PASS_2025 }, warnings);
-    expect(result).not.toBeNull();
-    expect(result!.depassement).toBe(true);
-    expect(warnings.some(w => w.code === 'PER_MADELIN_DEPASSE')).toBe(true);
-  });
-});
-
-// ── Full integration tests ───────────────────────────────────────────────────
-
 describe('calculatePerPotentiel', () => {
-  it('célibataire salarié TMI 30%, 80k', () => {
-    const input = makeInput({
-      situationFiscale: {
-        situationFamiliale: 'celibataire',
-        nombreParts: 1,
-        isole: false,
-        declarant1: makeDeclarant({ salaires: 80000 }),
-      },
-    });
-    const result = calculatePerPotentiel(input);
+  it('utilise le potentiel 163 quatervicies de l’avis IR saisi', () => {
+    const result = calculatePerPotentiel(makeInput());
 
-    expect(result.estTNS).toBe(false);
-    expect(result.plafondMadelin).toBeUndefined();
-    expect(result.plafond163Q.declarant1.plafondCalculeN).toBeGreaterThan(0);
-    expect(result.plafond163Q.declarant1.disponibleRestant).toBeGreaterThan(0);
-    expect(result.situationFiscale.tmi).toBeGreaterThan(0);
-    expect(result.situationFiscale.irEstime).toBeGreaterThan(0);
+    expect(result.plafond163Q.declarant1.totalDisponible).toBe(10000);
+    expect(result.deductionFlow163Q.declarant1.cotisationsRetenuesIr).toBe(3000);
+    expect(result.deductionFlow163Q.declarant1.disponibleRestant).toBe(7000);
   });
 
-  it('couple marié avec mutualisation', () => {
-    const input = makeInput({
-      situationFiscale: {
-        situationFamiliale: 'marie',
-        nombreParts: 2,
-        isole: false,
-        declarant1: makeDeclarant({ salaires: 80000 }),
-        declarant2: makeDeclarant({ salaires: 30000 }),
-      },
-      mutualisationConjoints: true,
-    });
-    const result = calculatePerPotentiel(input);
-
-    expect(result.plafond163Q.declarant2).toBeDefined();
-    expect(result.plafond163Q.declarant1.plafondCalculeN).toBeGreaterThan(0);
-    expect(result.plafond163Q.declarant2!.plafondCalculeN).toBeGreaterThan(0);
-    expect(result.situationFiscale.irEstime).toBeGreaterThan(0);
-    expect(result.declaration2042.case6QR).toBe(true);
-  });
-
-  it('parent isolé', () => {
-    const input = makeInput({
-      situationFiscale: {
-        situationFamiliale: 'celibataire',
-        nombreParts: 1.5,
-        isole: true,
-        declarant1: makeDeclarant({ salaires: 50000 }),
-      },
-    });
-    const result = calculatePerPotentiel(input);
-
-    expect(result.situationFiscale.irEstime).toBeGreaterThanOrEqual(0);
-    expect(result.plafond163Q.declarant1.plafondCalculeN).toBeGreaterThan(0);
-  });
-
-  it('TNS Madelin BIC 120k — both 163Q and Madelin computed', () => {
-    const input = makeInput({
-      situationFiscale: {
-        situationFamiliale: 'celibataire',
-        nombreParts: 1,
-        isole: false,
-        declarant1: makeDeclarant({ bic: 120000 }),
-      },
-    });
-    const result = calculatePerPotentiel(input);
-
-    expect(result.estTNS).toBe(true);
-    expect(result.plafondMadelin).toBeDefined();
-    expect(result.plafondMadelin!.declarant1.potentielTotal).toBeGreaterThan(0);
-    expect(result.plafond163Q.declarant1.plafondCalculeN).toBeGreaterThan(0);
-  });
-
-  it('mode déclaration avec avis IR', () => {
-    const input = makeInput({
-      mode: 'declaration-n1',
-      avisIr: {
-        nonUtiliseAnnee1: 2000,
-        nonUtiliseAnnee2: 3000,
-        nonUtiliseAnnee3: 1500,
-        plafondCalcule: 4710,
-        anneeRef: 2024,
-      },
-      situationFiscale: {
-        situationFamiliale: 'celibataire',
-        nombreParts: 1,
-        isole: false,
-        declarant1: makeDeclarant({
-          salaires: 60000,
-          cotisationsPer163Q: 3000,
-        }),
-      },
-    });
-    const result = calculatePerPotentiel(input);
-
-    // Should include carry-forward amounts
-    expect(result.plafond163Q.declarant1.nonUtiliseN1).toBe(1500);
-    expect(result.plafond163Q.declarant1.nonUtiliseN2).toBe(3000);
-    expect(result.plafond163Q.declarant1.nonUtiliseN3).toBe(2000);
-    // Cotisations already declared
-    expect(result.plafond163Q.declarant1.cotisationsDejaVersees).toBe(3000);
-    // disponible should be plafondN + carry-forward - cotisations
-    expect(result.plafond163Q.declarant1.disponibleRestant).toBeGreaterThan(0);
-  });
-
-  it('dépassement plafond → warning', () => {
-    const input = makeInput({
-      situationFiscale: {
-        situationFamiliale: 'celibataire',
-        nombreParts: 1,
-        isole: false,
-        declarant1: makeDeclarant({
-          salaires: 30000,
-          cotisationsPer163Q: 10000,
-        }),
-      },
-    });
-    const result = calculatePerPotentiel(input);
-
-    expect(result.plafond163Q.declarant1.depassement).toBe(true);
-    expect(result.warnings.some(w => w.code === 'PER_PLAFOND_163Q_DEPASSE')).toBe(true);
-  });
-
-  it('simulation versement — calculates économie IR', () => {
-    const input = makeInput({
-      versementEnvisage: 5000,
-      situationFiscale: {
-        situationFamiliale: 'celibataire',
-        nombreParts: 1,
-        isole: false,
-        declarant1: makeDeclarant({ salaires: 80000 }),
-      },
-    });
-    const result = calculatePerPotentiel(input);
-
-    expect(result.simulation).toBeDefined();
-    expect(result.simulation!.versementEnvisage).toBe(5000);
-    expect(result.situationFiscale.tmi).toBe(0.3);
-    expect(result.simulation!.versementDeductible).toBe(5000);
-    expect(result.simulation!.economieIRAnnuelle).toBe(1500);
-    expect(result.simulation!.coutNetApresFiscalite).toBe(3500);
-    expect(result.simulation!.plafondRestantApres).toBe(2200);
-  });
-
-  it('estimation sans avis — works with defaults (0 carry-forward)', () => {
-    const input = makeInput({
-      mode: 'versement-n',
-      // No avisIr provided
+  it('fait chuter le disponible restant quand les cotisations 163Q augmentent', () => {
+    const withoutContributions = calculatePerPotentiel(makeInput({
       situationFiscale: {
         situationFamiliale: 'celibataire',
         nombreParts: 1,
         isole: false,
         declarant1: makeDeclarant({ salaires: 60000 }),
       },
-    });
-    const result = calculatePerPotentiel(input);
+    }));
+    const withContributions = calculatePerPotentiel(makeInput({
+      situationFiscale: {
+        situationFamiliale: 'celibataire',
+        nombreParts: 1,
+        isole: false,
+        declarant1: makeDeclarant({ salaires: 60000, cotisationsPer163Q: 2000, cotisationsPerp: 300 }),
+      },
+    }));
 
-    expect(result.plafond163Q.declarant1.nonUtiliseN1).toBe(0);
-    expect(result.plafond163Q.declarant1.nonUtiliseN2).toBe(0);
-    expect(result.plafond163Q.declarant1.nonUtiliseN3).toBe(0);
-    expect(result.plafond163Q.declarant1.plafondCalculeN).toBeGreaterThan(0);
+    expect(withoutContributions.deductionFlow163Q.declarant1.disponibleRestant).toBe(10000);
+    expect(withContributions.deductionFlow163Q.declarant1.disponibleRestant).toBe(7700);
+  });
+
+  it('dérive correctement les cases 6OS / 6QS pour un TNS', () => {
+    const result = calculatePerPotentiel(makeInput({
+      situationFiscale: {
+        situationFamiliale: 'celibataire',
+        nombreParts: 1,
+        isole: false,
+        declarant1: makeDeclarant({
+          statutTns: true,
+          bic: 100000,
+          cotisationsArt83: 1000,
+          abondementPerco: 500,
+          cotisationsMadelinRetraite: 8000,
+          cotisationsMadelin154bis: 6000,
+        }),
+      },
+    }));
+
+    expect(result.estTNS).toBe(true);
+    expect(result.declaration2042.case6OS).toBe(6000);
+    expect(result.declaration2042.case6QS).toBe(1565);
+    expect(result.plafondMadelin?.declarant1.enveloppe15Versement).toBeGreaterThan(0);
+  });
+
+  it('ne déduit pas le Madelin du RBG quand il reste dans ses enveloppes', () => {
+    const baseInput = makeInput({
+      situationFiscale: {
+        situationFamiliale: 'celibataire',
+        nombreParts: 1,
+        isole: false,
+        declarant1: makeDeclarant({
+          statutTns: true,
+          bic: 90000,
+          cotisationsPer163Q: 3000,
+        }),
+      },
+    });
+
+    const sansMadelin = calculatePerPotentiel(baseInput);
+    const avecMadelin = calculatePerPotentiel({
+      ...baseInput,
+      situationFiscale: {
+        ...baseInput.situationFiscale,
+        declarant1: makeDeclarant({
+          statutTns: true,
+          bic: 90000,
+          cotisationsPer163Q: 3000,
+          cotisationsMadelinRetraite: 4000,
+          cotisationsMadelin154bis: 2000,
+          cotisationsPrevo: 500,
+        }),
+      },
+    });
+
+    expect(avecMadelin.situationFiscale.irEstime).toBe(sansMadelin.situationFiscale.irEstime);
+  });
+
+  it('réintègre le surplus Madelin dans la base TNS', () => {
+    const withoutOverflow = calculatePerPotentiel(makeInput({
+      situationFiscale: {
+        situationFamiliale: 'celibataire',
+        nombreParts: 1,
+        isole: false,
+        declarant1: makeDeclarant({
+          statutTns: true,
+          bic: 30000,
+          cotisationsPer163Q: 2000,
+        }),
+      },
+    }));
+
+    const withOverflow = calculatePerPotentiel(makeInput({
+      situationFiscale: {
+        situationFamiliale: 'celibataire',
+        nombreParts: 1,
+        isole: false,
+        declarant1: makeDeclarant({
+          statutTns: true,
+          bic: 30000,
+          cotisationsPer163Q: 2000,
+          cotisationsMadelinRetraite: 6000,
+          cotisationsMadelin154bis: 5000,
+        }),
+      },
+    }));
+
+    expect(withOverflow.plafondMadelin?.declarant1.surplusAReintegrer).toBeGreaterThan(0);
+    expect(withOverflow.situationFiscale.irEstime).toBeGreaterThan(withoutOverflow.situationFiscale.irEstime);
+  });
+
+  it('applique la mutualisation des conjoints au niveau moteur', () => {
+    const result = calculatePerPotentiel(makeInput({
+      situationFiscale: {
+        situationFamiliale: 'marie',
+        nombreParts: 2,
+        isole: false,
+        declarant1: makeDeclarant({ salaires: 70000, cotisationsPer163Q: 12000 }),
+        declarant2: makeDeclarant({ salaires: 30000, cotisationsPer163Q: 0 }),
+      },
+      avisIr: makeAvis({ nonUtiliseAnnee1: 0, nonUtiliseAnnee2: 0, nonUtiliseAnnee3: 0, plafondCalcule: 10000 }),
+      avisIr2: makeAvis({ nonUtiliseAnnee1: 0, nonUtiliseAnnee2: 0, nonUtiliseAnnee3: 0, plafondCalcule: 6000 }),
+      mutualisationConjoints: true,
+    }));
+
+    expect(result.declaration2042.case6QR).toBe(true);
+    expect(result.deductionFlow163Q.declarant1.cotisationsRetenuesIr).toBe(12000);
+    expect(result.deductionFlow163Q.declarant1.mutualisationRecue).toBe(2000);
+    expect(result.deductionFlow163Q.declarant2?.plafondApresMutualisation).toBe(4000);
+    expect(result.deductionFlow163Q.declarant2?.mutualisationCedee).toBe(2000);
+    expect(result.projectionAvisSuivant.declarant2?.nonUtiliseN).toBe(4000);
+  });
+
+  it('consomme le plafond de l’année avant les reports plus anciens', () => {
+    const result = calculatePerPotentiel(makeInput({
+      situationFiscale: {
+        situationFamiliale: 'celibataire',
+        nombreParts: 1,
+        isole: false,
+        declarant1: makeDeclarant({ cotisationsPer163Q: 250 }),
+      },
+      avisIr: makeAvis({
+        nonUtiliseAnnee1: 100,
+        nonUtiliseAnnee2: 200,
+        nonUtiliseAnnee3: 300,
+        plafondCalcule: 400,
+      }),
+    }));
+
+    expect(result.projectionAvisSuivant.declarant1.nonUtiliseN2).toBe(200);
+    expect(result.projectionAvisSuivant.declarant1.nonUtiliseN1).toBe(300);
+    expect(result.projectionAvisSuivant.declarant1.nonUtiliseN).toBe(150);
+  });
+
+  it('projette le prochain plafond sans tenir compte des pensions et revenus patrimoniaux', () => {
+    const baseResult = calculatePerPotentiel(makeInput({
+      situationFiscale: {
+        situationFamiliale: 'celibataire',
+        nombreParts: 1,
+        isole: false,
+        declarant1: makeDeclarant({ salaires: 50000, bic: 5000 }),
+      },
+      avisIr: makeAvis({ nonUtiliseAnnee1: 0, nonUtiliseAnnee2: 0, nonUtiliseAnnee3: 0, plafondCalcule: 0 }),
+    }));
+    const withExtraIncome = calculatePerPotentiel(makeInput({
+      situationFiscale: {
+        situationFamiliale: 'celibataire',
+        nombreParts: 1,
+        isole: false,
+        declarant1: makeDeclarant({
+          salaires: 50000,
+          bic: 5000,
+          retraites: 40000,
+          fonciersNets: 12000,
+          autresRevenus: 6000,
+        }),
+      },
+      avisIr: makeAvis({ nonUtiliseAnnee1: 0, nonUtiliseAnnee2: 0, nonUtiliseAnnee3: 0, plafondCalcule: 0 }),
+    }));
+
+    expect(withExtraIncome.projectionAvisSuivant.declarant1.plafondCalculeN)
+      .toBe(baseResult.projectionAvisSuivant.declarant1.plafondCalculeN);
+  });
+
+  it('utilise bien le PASS 2025 en step revenus tant que la projection N n’est pas active', () => {
+    const result = calculatePerPotentiel(makeInput({
+      mode: 'versement-n',
+      historicalBasis: 'previous-avis-plus-n1',
+      anneeRef: 2025,
+      situationFiscale: {
+        situationFamiliale: 'celibataire',
+        nombreParts: 1,
+        isole: false,
+        declarant1: makeDeclarant(),
+      },
+      avisIr: makeAvis({ nonUtiliseAnnee1: 0, nonUtiliseAnnee2: 0, nonUtiliseAnnee3: 0, plafondCalcule: 0 }),
+      passHistory: {
+        2025: 47100,
+        2026: 48060,
+      },
+    }));
+
+    expect(result.projectionAvisSuivant.declarant1.plafondCalculeN).toBe(4710);
   });
 });

--- a/src/engine/per/__tests__/plafond163Q.test.ts
+++ b/src/engine/per/__tests__/plafond163Q.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it } from 'vitest';
-import { computeRevenuImposable, computePlafond163QBrut, computeReductions163Q } from '../plafond163Q';
+import {
+  computeRevenuActiviteProfessionnelle,
+  computePlafond163QBrut,
+  computeProjectedPlafond163Q,
+  computeReductions163Q,
+  computeRevenuImposable,
+} from '../plafond163Q';
 import type { DeclarantRevenus } from '../types';
 
 const PASS = 46368;
+const ABAT_SAL = { plafond: 14171, plancher: 495 };
+const ABAT_RET = { plafond: 4321, plancher: 442 };
 
 const EMPTY_DECLARANT: DeclarantRevenus = {
+  statutTns: false,
   salaires: 0,
   art62: 0,
   bic: 0,
@@ -23,52 +32,85 @@ const EMPTY_DECLARANT: DeclarantRevenus = {
 };
 
 describe('computeRevenuImposable', () => {
-  it('applique l\'abattement 10 % sur les salaires', () => {
+  it('applique l’abattement 10 % sur les salaires', () => {
     const d = { ...EMPTY_DECLARANT, salaires: 50000 };
-    const result = computeRevenuImposable(d, 14171, 495);
-    // 50000 * 0.1 = 5000 → abattement = 5000 (entre plancher et plafond)
-    expect(result).toBe(45000);
+    expect(computeRevenuImposable(d, ABAT_SAL, ABAT_RET)).toBe(45000);
   });
 
   it('applique les frais réels si activés', () => {
     const d = { ...EMPTY_DECLARANT, salaires: 50000, fraisReels: true, fraisReelsMontant: 8000 };
-    const result = computeRevenuImposable(d, 14171, 495);
-    expect(result).toBe(42000);
+    expect(computeRevenuImposable(d, ABAT_SAL, ABAT_RET)).toBe(42000);
   });
 
-  it('retourne 0 si aucun revenu', () => {
-    const result = computeRevenuImposable(EMPTY_DECLARANT, 14171, 495);
-    expect(result).toBe(0);
+  it('utilise la configuration retraites injectée', () => {
+    const d = { ...EMPTY_DECLARANT, retraites: 50000 };
+    expect(computeRevenuImposable(d, ABAT_SAL, ABAT_RET)).toBe(45679);
   });
 });
 
 describe('computePlafond163QBrut', () => {
-  it('applique le plafond minimum (10 % de 1 PASS) pour les petits revenus', () => {
-    const result = computePlafond163QBrut(10000, PASS);
-    // 10000 * 0.1 = 1000 < 10% PASS = 4637 → minimum appliqué
-    expect(result).toBe(Math.round(PASS * 0.1));
+  it('applique le plancher PASS pour les petits revenus', () => {
+    expect(computePlafond163QBrut(10000, PASS)).toBe(Math.round(PASS * 0.1));
   });
 
   it('calcule 10 % du revenu pour un revenu intermédiaire', () => {
-    const result = computePlafond163QBrut(80000, PASS);
-    expect(result).toBe(Math.round(80000 * 0.1));
+    expect(computePlafond163QBrut(80000, PASS)).toBe(8000);
   });
 
-  it('applique le plafond maximum (10 % de 8 PASS) pour les hauts revenus', () => {
-    const result = computePlafond163QBrut(500000, PASS);
-    expect(result).toBe(Math.round(8 * PASS * 0.1));
+  it('applique le plafond de 8 PASS pour les hauts revenus', () => {
+    expect(computePlafond163QBrut(500000, PASS)).toBe(Math.round(8 * PASS * 0.1));
   });
 });
 
 describe('computeReductions163Q', () => {
-  it('retourne 0 si aucune cotisation', () => {
-    const result = computeReductions163Q(EMPTY_DECLARANT, PASS);
-    expect(result).toBe(0);
+  it('borne la réduction au plafond brut', () => {
+    expect(computeReductions163Q(5000, 8000)).toBe(5000);
+  });
+});
+
+describe('computeProjectedPlafond163Q', () => {
+  it('déduit bien les flux 2042 du prochain plafond calculé', () => {
+    const projected = computeProjectedPlafond163Q({
+      revenuSource: { ...EMPTY_DECLARANT, salaires: 90000 },
+      cotisationSource: EMPTY_DECLARANT,
+      pass: PASS,
+      reduction2042: 3500,
+      abat10SalCfg: ABAT_SAL,
+      abat10RetCfg: ABAT_RET,
+    });
+
+    expect(projected).toBe(4600);
   });
 
-  it('inclut les cotisations art83 dans les réductions', () => {
-    const d = { ...EMPTY_DECLARANT, cotisationsArt83: 3000 };
-    const result = computeReductions163Q(d, PASS);
-    expect(result).toBeGreaterThanOrEqual(3000);
+  it('ignore les pensions, le foncier et les autres revenus dans la base projetée', () => {
+    const baseSource = { ...EMPTY_DECLARANT, salaires: 50000, art62: 10000, bic: 5000 };
+    const withNonProfessionalIncome = {
+      ...baseSource,
+      retraites: 60000,
+      fonciersNets: 15000,
+      autresRevenus: 7000,
+    };
+
+    expect(computeRevenuActiviteProfessionnelle(baseSource, ABAT_SAL)).toBe(59000);
+    expect(computeRevenuActiviteProfessionnelle(withNonProfessionalIncome, ABAT_SAL)).toBe(59000);
+
+    const projectedBase = computeProjectedPlafond163Q({
+      revenuSource: baseSource,
+      cotisationSource: EMPTY_DECLARANT,
+      pass: PASS,
+      reduction2042: 0,
+      abat10SalCfg: ABAT_SAL,
+      abat10RetCfg: ABAT_RET,
+    });
+    const projectedWithNonProfessionalIncome = computeProjectedPlafond163Q({
+      revenuSource: withNonProfessionalIncome,
+      cotisationSource: EMPTY_DECLARANT,
+      pass: PASS,
+      reduction2042: 0,
+      abat10SalCfg: ABAT_SAL,
+      abat10RetCfg: ABAT_RET,
+    });
+
+    expect(projectedWithNonProfessionalIncome).toBe(projectedBase);
   });
 });

--- a/src/engine/per/__tests__/plafondMadelin.test.ts
+++ b/src/engine/per/__tests__/plafondMadelin.test.ts
@@ -3,8 +3,10 @@ import { computeAssietteMadelin, computePlafondMadelin, isTNS } from '../plafond
 import type { DeclarantRevenus, PerWarning } from '../types';
 
 const PASS = 46368;
+const ABAT_SAL = { plafond: 14171, plancher: 495 };
 
 const EMPTY_DECLARANT: DeclarantRevenus = {
+  statutTns: false,
   salaires: 0,
   art62: 0,
   bic: 0,
@@ -23,48 +25,126 @@ const EMPTY_DECLARANT: DeclarantRevenus = {
 };
 
 describe('isTNS', () => {
-  it('retourne false pour un salarié sans BIC ni art62', () => {
-    expect(isTNS({ ...EMPTY_DECLARANT, salaires: 50000 })).toBe(false);
+  it('retourne false si le statut TNS n’est pas activé', () => {
+    expect(isTNS({ ...EMPTY_DECLARANT, bic: 80000 })).toBe(false);
   });
 
-  it('retourne true pour un TNS avec BIC', () => {
-    expect(isTNS({ ...EMPTY_DECLARANT, bic: 80000 })).toBe(true);
-  });
-
-  it('retourne true pour un gérant art62', () => {
-    expect(isTNS({ ...EMPTY_DECLARANT, art62: 60000 })).toBe(true);
+  it('retourne true si le statut TNS est activé', () => {
+    expect(isTNS({ ...EMPTY_DECLARANT, statutTns: true, bic: 80000 })).toBe(true);
   });
 });
 
 describe('computeAssietteMadelin', () => {
-  it('calcule l\'assiette à partir des revenus TNS + cotisations', () => {
-    const d = { ...EMPTY_DECLARANT, bic: 80000, cotisationsMadelinRetraite: 5000 };
-    expect(computeAssietteMadelin(d)).toBe(85000);
+  it('calcule l’assiette de versement avec les cotisations facultatives', () => {
+    const d = {
+      ...EMPTY_DECLARANT,
+      statutTns: true,
+      bic: 80000,
+      cotisationsMadelinRetraite: 5000,
+      cotisationsMadelin154bis: 3000,
+      cotisationsPrevo: 1000,
+    };
+    expect(computeAssietteMadelin(d)).toBe(89000);
   });
 });
 
 describe('computePlafondMadelin', () => {
   it('retourne null pour un non-TNS', () => {
     const warnings: PerWarning[] = [];
-    const result = computePlafondMadelin({ declarant: { ...EMPTY_DECLARANT, salaires: 50000 }, pass: PASS }, warnings);
+    const result = computePlafondMadelin({
+      declarant: { ...EMPTY_DECLARANT, salaires: 50000 },
+      pass: PASS,
+      abat10SalCfg: ABAT_SAL,
+    }, warnings);
     expect(result).toBeNull();
   });
 
-  it('calcule le plafond pour un TNS avec assiette sous 1 PASS', () => {
+  it('retourne un détail à zéro quand le statut TNS est actif sans base positive', () => {
     const warnings: PerWarning[] = [];
-    const result = computePlafondMadelin({ declarant: { ...EMPTY_DECLARANT, bic: 30000 }, pass: PASS }, warnings);
+    const result = computePlafondMadelin({
+      declarant: { ...EMPTY_DECLARANT, statutTns: true },
+      pass: PASS,
+      abat10SalCfg: ABAT_SAL,
+    }, warnings);
+
     expect(result).not.toBeNull();
-    // Assiette = 30000 < PASS → enveloppe15 = 0, enveloppe10 = PASS * 10% = 4637
-    expect(result!.enveloppe15).toBe(0);
-    expect(result!.enveloppe10).toBe(Math.round(PASS * 0.1));
+    expect(result!.assietteVersement).toBe(0);
+    expect(result!.assietteReport).toBe(0);
+    expect(result!.enveloppe10).toBe(0);
   });
 
-  it('calcule le plafond pour un TNS avec assiette entre 1 et 8 PASS', () => {
+  it('calcule les deux enveloppes pour un TNS sous 1 PASS', () => {
     const warnings: PerWarning[] = [];
-    const result = computePlafondMadelin({ declarant: { ...EMPTY_DECLARANT, bic: 100000 }, pass: PASS }, warnings);
+    const result = computePlafondMadelin({
+      declarant: { ...EMPTY_DECLARANT, statutTns: true, bic: 30000 },
+      pass: PASS,
+      abat10SalCfg: ABAT_SAL,
+    }, warnings);
+
     expect(result).not.toBeNull();
-    // Assiette = 100000 > PASS → enveloppe15 = (100000 - PASS) * 15%
-    expect(result!.enveloppe15).toBe(Math.round((100000 - PASS) * 0.15));
-    expect(result!.enveloppe10).toBe(Math.round(100000 * 0.1));
+    expect(result!.enveloppe15Versement).toBe(0);
+    expect(result!.enveloppe10).toBe(Math.round(PASS * 0.1));
+    expect(result!.surplusAReintegrer).toBe(0);
+  });
+
+  it('partage l’enveloppe 10 % avec art. 83, PERCO et les dépassements Madelin', () => {
+    const warnings: PerWarning[] = [];
+    const result = computePlafondMadelin({
+      declarant: {
+        ...EMPTY_DECLARANT,
+        statutTns: true,
+        bic: 100000,
+        cotisationsArt83: 2000,
+        abondementPerco: 1000,
+        cotisationsMadelinRetraite: 12000,
+        cotisationsMadelin154bis: 5000,
+      },
+      pass: PASS,
+      abat10SalCfg: ABAT_SAL,
+    }, warnings);
+
+    expect(result).not.toBeNull();
+    expect(result!.consommation10.art83).toBe(2000);
+    expect(result!.consommation10.perco).toBe(1000);
+    expect(result!.consommation10.total).toBeLessThanOrEqual(result!.enveloppe10);
+    expect(result!.depassement15Report.madelinRetraite).toBeGreaterThanOrEqual(0);
+  });
+
+  it('calcule la réintégration quand les enveloppes sont dépassées', () => {
+    const warnings: PerWarning[] = [];
+    const result = computePlafondMadelin({
+      declarant: {
+        ...EMPTY_DECLARANT,
+        statutTns: true,
+        bic: 30000,
+        cotisationsMadelinRetraite: 6000,
+        cotisationsMadelin154bis: 5000,
+      },
+      pass: PASS,
+      abat10SalCfg: ABAT_SAL,
+    }, warnings);
+
+    expect(result).not.toBeNull();
+    expect(result!.depassement).toBe(true);
+    expect(result!.surplusAReintegrer).toBeGreaterThan(0);
+    expect(warnings.some((warning) => warning.code === 'PER_MADELIN_REINTEGRATION')).toBe(true);
+  });
+
+  it('calcule l’assiette report sur art.62 + bic - frais professionnels', () => {
+    const warnings: PerWarning[] = [];
+    const result = computePlafondMadelin({
+      declarant: {
+        ...EMPTY_DECLARANT,
+        statutTns: true,
+        salaires: 30000,
+        art62: 10000,
+        bic: 5000,
+      },
+      pass: PASS,
+      abat10SalCfg: ABAT_SAL,
+    }, warnings);
+
+    expect(result).not.toBeNull();
+    expect(result!.assietteReport).toBe(11000);
   });
 });

--- a/src/engine/per/index.ts
+++ b/src/engine/per/index.ts
@@ -4,8 +4,17 @@
 
 export { calculatePerPotentiel } from './perPotentiel';
 export { estimerSituationFiscale } from './perIrEstimation';
-export { computePlafond163Q, computePlafond163QBrut, computeRevenuImposable } from './plafond163Q';
+export {
+  computePlafond163Q,
+  computePlafond163QBrut,
+  computeProjectedPlafond163Q,
+  computeProfessionalDeduction,
+  computeRevenuImposable,
+} from './plafond163Q';
 export { computePlafondMadelin, isTNS } from './plafondMadelin';
+export { computeDeclaration2042 } from './perDeclarationFlow';
+export { computePerDeductionFlow } from './perDeductionFlow';
+export { computeProjectionAvis } from './perProjectionAvis';
 
 export type {
   PerPotentielInput,
@@ -14,9 +23,13 @@ export type {
   DeclarantRevenus,
   AvisIrPlafonds,
   PerHistoricalBasis,
+  PerYearKey,
   SituationFiscaleInput,
   SituationFiscaleResult,
   PlafondDetail,
   PlafondMadelinDetail,
   SimulationVersement,
+  PerDeductionDetail,
+  PerDeductionFlow,
+  PerProjectionAvisDetail,
 } from './types';

--- a/src/engine/per/perDeclarationFlow.ts
+++ b/src/engine/per/perDeclarationFlow.ts
@@ -1,0 +1,48 @@
+import type { Declaration2042Boxes, DeclarantRevenus, PlafondMadelinDetail } from './types';
+
+interface Declaration2042Context {
+  declarant1: DeclarantRevenus;
+  declarant2?: DeclarantRevenus;
+  madelin1?: PlafondMadelinDetail | null;
+  madelin2?: PlafondMadelinDetail | null;
+  mutualisationConjoints: boolean;
+}
+
+function buildDeclarantBoxes(
+  declarant: DeclarantRevenus,
+  madelin: PlafondMadelinDetail | null | undefined,
+): Pick<Declaration2042Boxes, 'case6NS' | 'case6RS' | 'case6QS' | 'case6OS'> {
+  return {
+    case6NS: Math.max(0, declarant.cotisationsPer163Q || 0),
+    case6RS: Math.max(0, declarant.cotisationsPerp || 0),
+    case6QS: Math.round(
+      Math.max(0, declarant.cotisationsArt83 || 0) +
+      Math.max(0, declarant.abondementPerco || 0) +
+      Math.max(0, madelin?.depassement15Report.madelinRetraite || 0),
+    ),
+    case6OS: Math.round(Math.max(0, madelin?.depassement15Report.per154bis || 0)),
+  };
+}
+
+export function computeDeclaration2042({
+  declarant1,
+  declarant2,
+  madelin1,
+  madelin2,
+  mutualisationConjoints,
+}: Declaration2042Context): Declaration2042Boxes {
+  const d1Boxes = buildDeclarantBoxes(declarant1, madelin1);
+  const d2Boxes = declarant2 ? buildDeclarantBoxes(declarant2, madelin2) : null;
+
+  return {
+    case6NS: d1Boxes.case6NS,
+    case6NT: d2Boxes?.case6NS,
+    case6RS: d1Boxes.case6RS,
+    case6RT: d2Boxes?.case6RS,
+    case6QS: d1Boxes.case6QS,
+    case6QT: d2Boxes?.case6QS,
+    case6OS: d1Boxes.case6OS,
+    case6OT: d2Boxes?.case6OS,
+    case6QR: Boolean(declarant2 && mutualisationConjoints),
+  };
+}

--- a/src/engine/per/perDeductionFlow.ts
+++ b/src/engine/per/perDeductionFlow.ts
@@ -1,0 +1,84 @@
+import type { DeclarantRevenus, PerDeductionDetail, PerDeductionFlow, PlafondDetail } from './types';
+
+interface DeductionContext {
+  declarant1: DeclarantRevenus;
+  declarant2?: DeclarantRevenus;
+  plafond1: PlafondDetail;
+  plafond2?: PlafondDetail;
+  mutualisationConjoints: boolean;
+}
+
+function computePersonalContribution(declarant: DeclarantRevenus): number {
+  return Math.max(0, (declarant.cotisationsPer163Q || 0) + (declarant.cotisationsPerp || 0));
+}
+
+function buildDetail(
+  plafondDisponible: number,
+  cotisationsVersees: number,
+  mutualisationRecue: number,
+  mutualisationCedee: number,
+): PerDeductionDetail {
+  const plafondApresMutualisation = Math.max(0, plafondDisponible + mutualisationRecue - mutualisationCedee);
+  const cotisationsRetenuesIr = Math.min(cotisationsVersees, plafondApresMutualisation);
+  const cotisationsNonDeductibles = Math.max(0, cotisationsVersees - cotisationsRetenuesIr);
+  const disponibleRestant = Math.max(
+    0,
+    plafondDisponible - Math.min(plafondDisponible, cotisationsRetenuesIr) - mutualisationCedee,
+  );
+
+  return {
+    plafondDisponible,
+    plafondApresMutualisation,
+    cotisationsVersees,
+    cotisationsRetenuesIr,
+    cotisationsNonDeductibles,
+    mutualisationRecue,
+    mutualisationCedee,
+    disponibleRestant,
+  };
+}
+
+export function computePerDeductionFlow({
+  declarant1,
+  declarant2,
+  plafond1,
+  plafond2,
+  mutualisationConjoints,
+}: DeductionContext): PerDeductionFlow {
+  const cotisationsD1 = computePersonalContribution(declarant1);
+  const cotisationsD2 = declarant2 ? computePersonalContribution(declarant2) : 0;
+  const plafondDisponibleD1 = Math.max(0, plafond1.totalDisponible);
+  const plafondDisponibleD2 = Math.max(0, plafond2?.totalDisponible ?? 0);
+
+  const surplusD1 = Math.max(0, cotisationsD1 - plafondDisponibleD1);
+  const surplusD2 = Math.max(0, cotisationsD2 - plafondDisponibleD2);
+  const spareD1 = Math.max(0, plafondDisponibleD1 - cotisationsD1);
+  const spareD2 = Math.max(0, plafondDisponibleD2 - cotisationsD2);
+
+  const mutualisationRecueD1 = mutualisationConjoints ? Math.min(surplusD1, spareD2) : 0;
+  const mutualisationRecueD2 = mutualisationConjoints ? Math.min(surplusD2, spareD1) : 0;
+
+  const declarant1Detail = buildDetail(
+    plafondDisponibleD1,
+    cotisationsD1,
+    mutualisationRecueD1,
+    mutualisationRecueD2,
+  );
+
+  const declarant2Detail = declarant2
+    ? buildDetail(
+      plafondDisponibleD2,
+      cotisationsD2,
+      mutualisationRecueD2,
+      mutualisationRecueD1,
+    )
+    : undefined;
+
+  return {
+    declarant1: declarant1Detail,
+    declarant2: declarant2Detail,
+    totalDeductionsIr:
+      declarant1Detail.cotisationsRetenuesIr +
+      (declarant2Detail?.cotisationsRetenuesIr ?? 0),
+  };
+}

--- a/src/engine/per/perIrEstimation.ts
+++ b/src/engine/per/perIrEstimation.ts
@@ -8,14 +8,14 @@
 import { computeIrResult } from '../ir/compute';
 import { computeAbattement10 } from '../ir/adjustments';
 import type { DEFAULT_TAX_SETTINGS, DEFAULT_PS_SETTINGS } from '../../constants/settingsDefaults';
-import type { SituationFiscaleInput, SituationFiscaleResult } from './types';
+import type { PerYearKey, SituationFiscaleInput, SituationFiscaleResult } from './types';
 
 export interface IrEstimationParams {
   situationFiscale: SituationFiscaleInput;
   deductionsPer: number;
   taxSettings: typeof DEFAULT_TAX_SETTINGS;
   psSettings: typeof DEFAULT_PS_SETTINGS;
-  yearKey?: string;
+  yearKey?: PerYearKey;
 }
 
 /**

--- a/src/engine/per/perPotentiel.ts
+++ b/src/engine/per/perPotentiel.ts
@@ -10,11 +10,38 @@ import type {
   PerPotentielResult,
   PerWarning,
   SimulationVersement,
+  SituationFiscaleInput,
 } from './types';
-import { computePlafond163Q } from './plafond163Q';
-import { computePlafondMadelin, isTNS } from './plafondMadelin';
+import { computeDeclaration2042 } from './perDeclarationFlow';
+import { computePerDeductionFlow } from './perDeductionFlow';
+import {
+  computePlafond163Q,
+  computeProjectedPlafond163Q,
+} from './plafond163Q';
+import { computePlafondMadelin, createEmptyMadelinDetail, isTNS } from './plafondMadelin';
+import { computeProjectionAvis } from './perProjectionAvis';
 import { estimerSituationFiscale } from './perIrEstimation';
-import type { DEFAULT_TAX_SETTINGS, DEFAULT_PS_SETTINGS } from '../../constants/settingsDefaults';
+import type { DEFAULT_PS_SETTINGS, DEFAULT_TAX_SETTINGS } from '../../constants/settingsDefaults';
+
+function addMadelinReintegration(
+  situation: SituationFiscaleInput,
+  surplusD1: number,
+  surplusD2: number,
+): SituationFiscaleInput {
+  return {
+    ...situation,
+    declarant1: {
+      ...situation.declarant1,
+      bic: Math.max(0, (situation.declarant1.bic || 0) + surplusD1),
+    },
+    declarant2: situation.declarant2
+      ? {
+        ...situation.declarant2,
+        bic: Math.max(0, (situation.declarant2.bic || 0) + surplusD2),
+      }
+      : undefined,
+  };
+}
 
 /**
  * Calcule le potentiel épargne retraite complet.
@@ -24,6 +51,7 @@ export function calculatePerPotentiel(input: PerPotentielInput): PerPotentielRes
   const {
     mode,
     anneeRef,
+    yearKey = 'current',
     situationFiscale,
     projectionFiscale,
     avisIr,
@@ -40,90 +68,138 @@ export function calculatePerPotentiel(input: PerPotentielInput): PerPotentielRes
 
   const tax = taxSettings as typeof DEFAULT_TAX_SETTINGS;
   const ps = psSettings as typeof DEFAULT_PS_SETTINGS;
+  const abat10CfgRoot = tax?.incomeTax?.abat10 ?? {};
+  const abat10SalCfg = yearKey === 'current'
+    ? abat10CfgRoot.current ?? {}
+    : abat10CfgRoot.previous ?? {};
+  const abat10RetCfg = yearKey === 'current'
+    ? abat10CfgRoot.retireesCurrent ?? {}
+    : abat10CfgRoot.retireesPrevious ?? {};
 
-  const abat10Cfg = tax?.incomeTax?.abat10?.current;
-  const plafondAbat10 = abat10Cfg?.plafond ?? 14426;
-  const plancherAbat10 = abat10Cfg?.plancher ?? 504;
-
-  const { declarant1, declarant2 } = situationFiscale;
   const activeSituation = projectionFiscale ?? situationFiscale;
   const activeDeclarant1 = activeSituation.declarant1;
   const activeDeclarant2 = activeSituation.declarant2;
-  const declarationSource = mode === 'declaration-n1' ? situationFiscale : activeSituation;
 
-  const plafond163QD1 = computePlafond163Q(
-    { revenuSource: declarant1, cotisationSource: activeDeclarant1, pass, avisIr },
-    plafondAbat10, plancherAbat10, warnings,
-  );
+  const plafond163QD1 = computePlafond163Q({
+    cotisationSource: activeDeclarant1,
+    avisIr,
+    pass,
+    abat10SalCfg,
+    abat10RetCfg,
+  }, warnings);
 
-  let plafond163QD2;
-  if (declarant2) {
-    plafond163QD2 = computePlafond163Q(
-      { revenuSource: declarant2, cotisationSource: activeDeclarant2, pass, avisIr: avisIr2 },
-      plafondAbat10, plancherAbat10, warnings,
-    );
-  }
+  const plafond163QD2 = activeDeclarant2
+    ? computePlafond163Q({
+      cotisationSource: activeDeclarant2,
+      avisIr: avisIr2,
+      pass,
+      abat10SalCfg,
+      abat10RetCfg,
+    }, warnings)
+    : undefined;
 
-  const estTNSD1 = isTNS(activeDeclarant1);
-  const estTNSD2 = activeDeclarant2 ? isTNS(activeDeclarant2) : false;
-  const estTNS = estTNSD1 || estTNSD2;
+  const mad1 = computePlafondMadelin({
+    declarant: activeDeclarant1,
+    pass,
+    abat10SalCfg,
+  }, warnings);
+  const mad2 = activeDeclarant2
+    ? computePlafondMadelin({
+      declarant: activeDeclarant2,
+      pass,
+      abat10SalCfg,
+    }, warnings)
+    : null;
 
-  let plafondMadelin;
-  if (estTNS) {
-    const mad1 = computePlafondMadelin({ declarant: activeDeclarant1, pass }, warnings);
-    const mad2 = activeDeclarant2
-      ? computePlafondMadelin({ declarant: activeDeclarant2, pass }, warnings)
-      : undefined;
-
-    if (mad1 || mad2) {
-      plafondMadelin = {
-        declarant1: mad1!,
-        declarant2: mad2 ?? undefined,
-      };
+  const estTNS = Boolean(isTNS(activeDeclarant1) || (activeDeclarant2 && isTNS(activeDeclarant2)));
+  const plafondMadelin = estTNS
+    ? {
+      declarant1: mad1 ?? createEmptyMadelinDetail(),
+      declarant2: mad2 ?? undefined,
     }
-  }
+    : undefined;
 
-  const totalCotisationsDeductiblesD1 =
-    activeDeclarant1.cotisationsPer163Q +
-    activeDeclarant1.cotisationsPerp +
-    activeDeclarant1.cotisationsMadelin154bis +
-    activeDeclarant1.cotisationsMadelinRetraite;
-
-  const totalCotisationsDeductiblesD2 = activeDeclarant2
-    ? activeDeclarant2.cotisationsPer163Q +
-      activeDeclarant2.cotisationsPerp +
-      activeDeclarant2.cotisationsMadelin154bis +
-      activeDeclarant2.cotisationsMadelinRetraite
-      : 0;
-
-  const totalDeductionsPer = totalCotisationsDeductiblesD1 + totalCotisationsDeductiblesD2;
-
-  const situationFiscaleResult = estimerSituationFiscale({
-    situationFiscale: activeSituation,
-    deductionsPer: totalDeductionsPer,
-    taxSettings: tax,
-    psSettings: ps,
+  const declaration2042 = computeDeclaration2042({
+    declarant1: activeDeclarant1,
+    declarant2: activeDeclarant2,
+    madelin1: mad1,
+    madelin2: mad2,
+    mutualisationConjoints,
   });
 
-  const declaration2042 = {
-    case6NS: declarationSource.declarant1.cotisationsPer163Q,
-    case6NT: declarationSource.declarant2 ? declarationSource.declarant2.cotisationsPer163Q : undefined,
-    case6RS: declarationSource.declarant1.cotisationsPerp,
-    case6RT: declarationSource.declarant2 ? declarationSource.declarant2.cotisationsPerp : undefined,
-    case6QS: declarationSource.declarant1.cotisationsArt83,
-    case6QT: declarationSource.declarant2 ? declarationSource.declarant2.cotisationsArt83 : undefined,
-    case6OS: declarationSource.declarant1.cotisationsMadelin154bis,
-    case6OT: declarationSource.declarant2 ? declarationSource.declarant2.cotisationsMadelin154bis : undefined,
-    case6QR: Boolean(declarationSource.declarant2 && mutualisationConjoints),
-  };
+  const deductionFlow163Q = computePerDeductionFlow({
+    declarant1: activeDeclarant1,
+    declarant2: activeDeclarant2,
+    plafond1: plafond163QD1,
+    plafond2: plafond163QD2,
+    mutualisationConjoints,
+  });
+
+  if (deductionFlow163Q.declarant1.cotisationsNonDeductibles > 0) {
+    warnings.push({
+      code: 'PER_163Q_IR_NON_DEDUCTIBLE_D1',
+      message: `Une fraction des versements 163 quatervicies / PERP du déclarant 1 (${deductionFlow163Q.declarant1.cotisationsNonDeductibles.toLocaleString('fr-FR')} €) n'est pas retenue pour l'IR courant.`,
+      severity: 'warning',
+    });
+  }
+  if ((deductionFlow163Q.declarant2?.cotisationsNonDeductibles ?? 0) > 0) {
+    warnings.push({
+      code: 'PER_163Q_IR_NON_DEDUCTIBLE_D2',
+      message: `Une fraction des versements 163 quatervicies / PERP du déclarant 2 (${deductionFlow163Q.declarant2!.cotisationsNonDeductibles.toLocaleString('fr-FR')} €) n'est pas retenue pour l'IR courant.`,
+      severity: 'warning',
+    });
+  }
+
+  const adjustedSituation = addMadelinReintegration(
+    activeSituation,
+    mad1?.surplusAReintegrer ?? 0,
+    mad2?.surplusAReintegrer ?? 0,
+  );
+
+  const situationFiscaleResult = estimerSituationFiscale({
+    situationFiscale: adjustedSituation,
+    deductionsPer: deductionFlow163Q.totalDeductionsIr,
+    taxSettings: tax,
+    psSettings: ps,
+    yearKey,
+  });
+
+  const projectedPlafondD1 = computeProjectedPlafond163Q({
+    revenuSource: adjustedSituation.declarant1,
+    cotisationSource: activeDeclarant1,
+    avisIr,
+    reduction2042: declaration2042.case6QS + declaration2042.case6OS,
+    pass,
+    abat10SalCfg,
+    abat10RetCfg,
+  });
+
+  const projectedPlafondD2 = adjustedSituation.declarant2
+    ? computeProjectedPlafond163Q({
+      revenuSource: adjustedSituation.declarant2,
+      cotisationSource: activeDeclarant2!,
+      avisIr: avisIr2,
+      reduction2042: (declaration2042.case6QT ?? 0) + (declaration2042.case6OT ?? 0),
+      pass,
+      abat10SalCfg,
+      abat10RetCfg,
+    })
+    : undefined;
+
+  const projectionAvisSuivant = computeProjectionAvis({
+    avisIr,
+    avisIr2,
+    deductionFlow: deductionFlow163Q,
+    projectedPlafondD1,
+    projectedPlafondD2,
+  });
 
   let simulation: SimulationVersement | undefined;
   if (mode === 'versement-n' && versementEnvisage != null && versementEnvisage > 0) {
-    const plafondDispoD1 = plafond163QD1.disponibleRestant;
-    const plafondDispoD2 =
-      declarationSource.declarant2 && mutualisationConjoints
-        ? plafond163QD2?.disponibleRestant ?? 0
-        : 0;
+    const plafondDispoD1 = deductionFlow163Q.declarant1.disponibleRestant;
+    const plafondDispoD2 = mutualisationConjoints
+      ? deductionFlow163Q.declarant2?.disponibleRestant ?? 0
+      : 0;
     const totalDispo = plafondDispoD1 + plafondDispoD2;
     const versementDeductible = Math.min(versementEnvisage, totalDispo);
     const economie = Math.round(versementDeductible * situationFiscaleResult.tmi);
@@ -139,10 +215,12 @@ export function calculatePerPotentiel(input: PerPotentielInput): PerPotentielRes
 
   return {
     situationFiscale: situationFiscaleResult,
-      plafond163Q: { declarant1: plafond163QD1, declarant2: plafond163QD2 },
+    plafond163Q: { declarant1: plafond163QD1, declarant2: plafond163QD2 },
+    deductionFlow163Q,
     plafondMadelin,
     estTNS,
     declaration2042,
+    projectionAvisSuivant,
     simulation,
     warnings,
   };

--- a/src/engine/per/perProjectionAvis.ts
+++ b/src/engine/per/perProjectionAvis.ts
@@ -1,0 +1,80 @@
+import type { AvisIrPlafonds, PerDeductionFlow, PerProjectionAvisDetail } from './types';
+
+interface ProjectionDeclarantContext {
+  avisIr?: AvisIrPlafonds;
+  projectedPlafondCalcule: number;
+  plafondDisponibleRestant: number;
+  plafondDisponibleInitial: number;
+}
+
+interface ProjectionContext {
+  avisIr?: AvisIrPlafonds;
+  avisIr2?: AvisIrPlafonds;
+  deductionFlow: PerDeductionFlow;
+  projectedPlafondD1: number;
+  projectedPlafondD2?: number;
+}
+
+function allocateNextAvis({
+  avisIr,
+  projectedPlafondCalcule,
+  plafondDisponibleRestant,
+  plafondDisponibleInitial,
+}: ProjectionDeclarantContext): PerProjectionAvisDetail {
+  const ancienN2 = avisIr?.nonUtiliseAnnee2 ?? 0;
+  const ancienN1 = avisIr?.nonUtiliseAnnee3 ?? 0;
+  const ancienN = avisIr?.plafondCalcule ?? 0;
+  const ancienN3 = avisIr?.nonUtiliseAnnee1 ?? 0;
+  const consommation = Math.max(0, Math.round(plafondDisponibleInitial - plafondDisponibleRestant));
+
+  let resteAImputer = consommation;
+  const consommationSurPlafondAnnee = Math.min(resteAImputer, Math.max(0, ancienN));
+  resteAImputer -= consommationSurPlafondAnnee;
+  const nonUtiliseN = Math.max(0, Math.round(ancienN - consommationSurPlafondAnnee));
+
+  const consommationSurAncienN3 = Math.min(resteAImputer, Math.max(0, ancienN3));
+  resteAImputer -= consommationSurAncienN3;
+
+  const nonUtiliseN2 = Math.max(0, Math.round(ancienN2 - resteAImputer));
+  resteAImputer = Math.max(0, resteAImputer - ancienN2);
+
+  const nonUtiliseN1 = Math.max(0, Math.round(ancienN1 - resteAImputer));
+  const plafondCalculeN = Math.max(0, Math.round(projectedPlafondCalcule));
+
+  return {
+    nonUtiliseN2,
+    nonUtiliseN1,
+    nonUtiliseN,
+    plafondCalculeN,
+    plafondTotal: Math.round(nonUtiliseN2 + nonUtiliseN1 + nonUtiliseN + plafondCalculeN),
+  };
+}
+
+export function computeProjectionAvis({
+  avisIr,
+  avisIr2,
+  deductionFlow,
+  projectedPlafondD1,
+  projectedPlafondD2,
+}: ProjectionContext): {
+  declarant1: PerProjectionAvisDetail;
+  declarant2?: PerProjectionAvisDetail;
+} {
+  const declarant1 = allocateNextAvis({
+    avisIr,
+    projectedPlafondCalcule: projectedPlafondD1,
+    plafondDisponibleInitial: deductionFlow.declarant1.plafondDisponible,
+    plafondDisponibleRestant: deductionFlow.declarant1.disponibleRestant,
+  });
+
+  const declarant2 = deductionFlow.declarant2
+    ? allocateNextAvis({
+      avisIr: avisIr2,
+      projectedPlafondCalcule: projectedPlafondD2 ?? 0,
+      plafondDisponibleInitial: deductionFlow.declarant2.plafondDisponible,
+      plafondDisponibleRestant: deductionFlow.declarant2.disponibleRestant,
+    })
+    : undefined;
+
+  return { declarant1, declarant2 };
+}

--- a/src/engine/per/plafond163Q.ts
+++ b/src/engine/per/plafond163Q.ts
@@ -1,43 +1,96 @@
 /**
- * Plafond 163 Quatervicies — calcul du plafond personnel épargne retraite.
+ * Plafond 163 quatervicies — calcul du potentiel PER individuel.
  *
- * CGI Art. 163 quatervicies :
- * - 10% des revenus imposables (après abattement 10% si applicable)
- * - Minimum : 10% de 1 PASS
- * - Maximum : 10% de 8 PASS
- * - Réductions : art83, excédent Madelin, PERCO
+ * Le plafond utilisable pour les versements 163 quatervicies / PERP de l'année
+ * provient de l'avis IR saisi. Les revenus courants servent à projeter le
+ * plafond calculé du prochain avis IR.
  */
 
-import type { DeclarantRevenus, PlafondDetail, AvisIrPlafonds, PerWarning } from './types';
+import type { AvisIrPlafonds, DeclarantRevenus, PerWarning, PlafondDetail } from './types';
+
+export interface PerAbattementConfigLike {
+  plafond?: number | string | null;
+  plancher?: number | string | null;
+}
 
 export interface Plafond163QParams {
-  revenuSource: DeclarantRevenus;
-  cotisationSource?: DeclarantRevenus;
-  pass: number;
+  revenuSource?: DeclarantRevenus;
+  cotisationSource: DeclarantRevenus;
   avisIr?: AvisIrPlafonds;
+  reduction2042?: number;
+  pass: number;
+  abat10SalCfg: PerAbattementConfigLike;
+  abat10RetCfg: PerAbattementConfigLike;
+}
+
+function toNumber(value: number | string | null | undefined, fallback: number): number {
+  const parsed = typeof value === 'string' ? Number(value) : value;
+  return Number.isFinite(parsed) ? Number(parsed) : fallback;
+}
+
+export function computeProfessionalDeduction(
+  d: DeclarantRevenus,
+  abat10SalCfg: PerAbattementConfigLike,
+): number {
+  if (d.fraisReels && d.fraisReelsMontant > 0) {
+    return Math.max(0, d.fraisReelsMontant);
+  }
+
+  const plafondAbat10 = toNumber(abat10SalCfg.plafond, 0);
+  const plancherAbat10 = toNumber(abat10SalCfg.plancher, 0);
+  const salBrut = (d.salaires || 0) + (d.art62 || 0);
+
+  return salBrut > 0
+    ? Math.min(Math.max(salBrut * 0.1, plancherAbat10), plafondAbat10)
+    : 0;
 }
 
 /**
  * Calcule le revenu imposable net d'un déclarant (après abattement 10% ou frais réels).
  */
-export function computeRevenuImposable(d: DeclarantRevenus, plafondAbat10: number, plancherAbat10: number): number {
-  const salBrut = d.salaires + d.art62;
-  let abattement: number;
-  if (d.fraisReels && d.fraisReelsMontant > 0) {
-    abattement = d.fraisReelsMontant;
-  } else {
-    abattement = Math.min(Math.max(salBrut * 0.1, plancherAbat10), plafondAbat10);
-  }
-  const salNet = Math.max(0, salBrut - abattement);
+export function computeRevenuImposable(
+  d: DeclarantRevenus,
+  abat10SalCfg: PerAbattementConfigLike,
+  abat10RetCfg: PerAbattementConfigLike,
+): number {
+  const salDeduction = computeProfessionalDeduction(d, abat10SalCfg);
+  const salNet = Math.max(0, (d.salaires || 0) + (d.art62 || 0) - salDeduction);
 
-  const plafondAbatRetraites = 4399;
-  const plancherAbatRetraites = 450;
-  const abatRetraites = d.retraites > 0
-    ? Math.min(Math.max(d.retraites * 0.1, plancherAbatRetraites), plafondAbatRetraites)
+  const plafondAbatRetraites = toNumber(abat10RetCfg.plafond, 0);
+  const plancherAbatRetraites = toNumber(abat10RetCfg.plancher, 0);
+  const abatRetraites = (d.retraites || 0) > 0
+    ? Math.min(
+      Math.max((d.retraites || 0) * 0.1, plancherAbatRetraites),
+      plafondAbatRetraites,
+    )
     : 0;
-  const pensionsNet = Math.max(0, d.retraites - abatRetraites);
+  const pensionsNet = Math.max(0, (d.retraites || 0) - abatRetraites);
 
-  return salNet + d.bic + pensionsNet + d.fonciersNets + d.autresRevenus;
+  return Math.round(
+    salNet +
+    (d.bic || 0) +
+    pensionsNet +
+    (d.fonciersNets || 0) +
+    (d.autresRevenus || 0),
+  );
+}
+
+/**
+ * Base d'activité professionnelle retenue pour le plafond projeté du prochain avis IR.
+ * Alignement classeur : salaires + art.62 - frais pro + BIC.
+ */
+export function computeRevenuActiviteProfessionnelle(
+  d: DeclarantRevenus,
+  abat10SalCfg: PerAbattementConfigLike,
+): number {
+  const salDeduction = computeProfessionalDeduction(d, abat10SalCfg);
+
+  return Math.round(
+    (d.salaires || 0) +
+    (d.art62 || 0) -
+    salDeduction +
+    (d.bic || 0),
+  );
 }
 
 /**
@@ -50,66 +103,33 @@ export function computePlafond163QBrut(revenuImposable: number, pass: number): n
   return Math.round(Math.min(Math.max(plafondBrut, minPlafond), maxPlafond));
 }
 
-/**
- * Calcule les réductions sur le plafond 163Q (art83, excédent Madelin, PERCO).
- */
-export function computeReductions163Q(d: DeclarantRevenus, pass: number): number {
-  const reductionArt83 = d.cotisationsArt83;
-  const madelinMax = Math.max(0, (d.bic - pass)) * 0.15;
-  const madelinVerse = d.cotisationsMadelinRetraite + d.cotisationsMadelin154bis;
-  const reductionMadelinExcess = Math.max(0, madelinVerse - madelinMax);
-  const reductionPerco = d.abondementPerco;
-  return Math.round(reductionArt83 + reductionMadelinExcess + reductionPerco);
+export function computeReductions163Q(plafondBrut: number, reduction2042: number): number {
+  return Math.round(Math.min(Math.max(0, reduction2042), Math.max(0, plafondBrut)));
 }
 
-/**
- * Calcule le plafond 163Q complet pour un déclarant, avec report en avant.
- */
-export function computePlafond163Q(
-  params: Plafond163QParams,
-  plafondAbat10: number,
-  plancherAbat10: number,
+function mapAvisToPlafondDetail(
+  avisIr: AvisIrPlafonds | undefined,
+  cotisationsVersees: number,
   warnings: PerWarning[],
 ): PlafondDetail {
-  const { revenuSource, cotisationSource, pass, avisIr } = params;
-  const declarantCotisations = cotisationSource ?? revenuSource;
-
-  const revenuImposable = computeRevenuImposable(revenuSource, plafondAbat10, plancherAbat10);
-  const plafondBrut = computePlafond163QBrut(revenuImposable, pass);
-  const reductions = computeReductions163Q(declarantCotisations, pass);
-  const plafondNet = Math.max(0, plafondBrut - reductions);
-
-  const nonUtiliseN1 = avisIr?.nonUtiliseAnnee3 ?? 0;
-  const nonUtiliseN2 = avisIr?.nonUtiliseAnnee2 ?? 0;
   const nonUtiliseN3 = avisIr?.nonUtiliseAnnee1 ?? 0;
-
-  const totalDisponible = plafondNet + nonUtiliseN1 + nonUtiliseN2 + nonUtiliseN3;
-
-  const cotisationsVersees =
-    declarantCotisations.cotisationsPer163Q +
-    declarantCotisations.cotisationsPerp;
-
+  const nonUtiliseN2 = avisIr?.nonUtiliseAnnee2 ?? 0;
+  const nonUtiliseN1 = avisIr?.nonUtiliseAnnee3 ?? 0;
+  const plafondCalculeN = avisIr?.plafondCalcule ?? 0;
+  const totalDisponible = nonUtiliseN3 + nonUtiliseN2 + nonUtiliseN1 + plafondCalculeN;
   const disponibleRestant = totalDisponible - cotisationsVersees;
   const depassement = disponibleRestant < 0;
 
   if (depassement) {
     warnings.push({
       code: 'PER_PLAFOND_163Q_DEPASSE',
-      message: `Dépassement du plafond 163Q : les versements (${cotisationsVersees.toLocaleString('fr-FR')} €) dépassent le plafond disponible (${totalDisponible.toLocaleString('fr-FR')} €).`,
+      message: `Les cotisations 163 quatervicies / PERP (${cotisationsVersees.toLocaleString('fr-FR')} €) dépassent le potentiel disponible issu de l'avis IR (${totalDisponible.toLocaleString('fr-FR')} €).`,
       severity: 'warning',
     });
   }
 
-  if (declarantCotisations.cotisationsPrevo > 0) {
-    warnings.push({
-      code: 'PER_PREVOYANCE_WARNING',
-      message: 'Les cotisations prévoyance Madelin entrent dans le calcul du plafond Madelin. Vérifiez l\'impact sur votre enveloppe.',
-      severity: 'info',
-    });
-  }
-
   return {
-    plafondCalculeN: plafondNet,
+    plafondCalculeN,
     nonUtiliseN1,
     nonUtiliseN2,
     nonUtiliseN3,
@@ -118,4 +138,46 @@ export function computePlafond163Q(
     disponibleRestant: Math.max(0, disponibleRestant),
     depassement,
   };
+}
+
+/**
+ * Calcule le détail 163Q courant à partir de l'avis IR saisi.
+ */
+export function computePlafond163Q(
+  params: Plafond163QParams,
+  warnings: PerWarning[],
+): PlafondDetail {
+  const { cotisationSource } = params;
+  const cotisationsVersees =
+    (cotisationSource.cotisationsPer163Q || 0) +
+    (cotisationSource.cotisationsPerp || 0);
+
+  if ((cotisationSource.cotisationsPrevo || 0) > 0) {
+    warnings.push({
+      code: 'PER_PREVOYANCE_WARNING',
+      message: 'Les cotisations prévoyance Madelin entrent dans le calcul du potentiel 154 bis. Vérifiez leur impact sur l’assiette TNS.',
+      severity: 'info',
+    });
+  }
+
+  return mapAvisToPlafondDetail(params.avisIr, cotisationsVersees, warnings);
+}
+
+/**
+ * Calcule le plafond 163Q projeté pour le prochain avis IR.
+ */
+export function computeProjectedPlafond163Q(
+  params: Plafond163QParams,
+): number {
+  if (!params.revenuSource) {
+    return 0;
+  }
+
+  const revenuActivite = computeRevenuActiviteProfessionnelle(
+    params.revenuSource,
+    params.abat10SalCfg,
+  );
+  const plafondBrut = computePlafond163QBrut(revenuActivite, params.pass);
+  const reductions = computeReductions163Q(plafondBrut, params.reduction2042 ?? 0);
+  return Math.max(0, plafondBrut - reductions);
 }

--- a/src/engine/per/plafondMadelin.ts
+++ b/src/engine/per/plafondMadelin.ts
@@ -1,91 +1,233 @@
 /**
- * Plafond Madelin 154 bis — calcul de l'enveloppe TNS.
+ * Plafond Madelin 154 bis — calcul détaillé des enveloppes TNS.
  *
- * CGI Art. 154 bis :
- * - Enveloppe 15% : (revenus > 1 PASS, max 8 PASS) × 15%
- * - Enveloppe 10% : min 10% PASS, max 10% de 8 PASS
- * - Assiette : BIC/BNC + art62 + cotisations Madelin + PERin 154bis + prévoyance
+ * Référence métier :
+ * - assiette de versement = BIC + art.62 + Madelin retraite + PER 154 bis + prévoyance
+ * - enveloppe 15% de versement = 15% de l'assiette au-delà d'1 PASS, plafonnée à 8 PASS
+ * - enveloppe 10% commune = partagée avec art. 83, PERCO/PERECO et dépassements Madelin
+ * - enveloppe 15% de report 2042 = recalculée sur la base imposable TNS après frais pro
  */
 
-import type { DeclarantRevenus, PlafondMadelinDetail, PerWarning } from './types';
+import { computeProfessionalDeduction, type PerAbattementConfigLike } from './plafond163Q';
+import type { DeclarantRevenus, PerWarning, PlafondMadelinDetail } from './types';
 
 export interface PlafondMadelinParams {
   declarant: DeclarantRevenus;
   pass: number;
+  abat10SalCfg: PerAbattementConfigLike;
+}
+
+export function createEmptyMadelinDetail(): PlafondMadelinDetail {
+  return {
+    assietteVersement: 0,
+    assietteReport: 0,
+    enveloppe15Versement: 0,
+    enveloppe15Report: 0,
+    enveloppe10: 0,
+    cotisationsVersees: 0,
+    utilisation15Versement: { madelinRetraite: 0, per154bis: 0, total: 0 },
+    depassement15Versement: { madelinRetraite: 0, per154bis: 0, total: 0 },
+    utilisation15Report: { madelinRetraite: 0, per154bis: 0, total: 0 },
+    depassement15Report: { madelinRetraite: 0, per154bis: 0, total: 0 },
+    consommation10: { art83: 0, perco: 0, madelinRetraite: 0, per154bis: 0, total: 0 },
+    reste15Versement: 0,
+    reste15Report: 0,
+    reste10: 0,
+    disponibleRestant: 0,
+    surplusAReintegrer: 0,
+    depassement: false,
+  };
+}
+
+function clampAssiette(assiette: number, pass: number): number {
+  return Math.max(0, Math.min(assiette, 8 * pass));
+}
+
+function computeEnvelope15(assiette: number, pass: number): number {
+  const assietteCappee = clampAssiette(assiette, pass);
+  if (assietteCappee <= pass) {
+    return 0;
+  }
+  return Math.round((assietteCappee - pass) * 0.15);
+}
+
+function computeEnvelope10(baseTns: number, assiette: number, pass: number): number {
+  if (baseTns <= 0) {
+    return 0;
+  }
+
+  if (assiette <= pass) {
+    return Math.round(pass * 0.1);
+  }
+
+  return Math.round(clampAssiette(assiette, pass) * 0.1);
+}
+
+function computeAssietteReport(
+  declarant: DeclarantRevenus,
+  abat10SalCfg: PerAbattementConfigLike,
+): number {
+  const deductionProfessionnelle = computeProfessionalDeduction(declarant, abat10SalCfg);
+  return Math.max(0, (declarant.art62 || 0) + (declarant.bic || 0) - deductionProfessionnelle);
+}
+
+function allocateSequentially(
+  envelope10: number,
+  demands: Array<{ key: 'art83' | 'perco' | 'madelinRetraite' | 'per154bis'; amount: number }>,
+): PlafondMadelinDetail['consommation10'] {
+  let remaining = Math.max(0, envelope10);
+  const allocation: PlafondMadelinDetail['consommation10'] = {
+    art83: 0,
+    perco: 0,
+    madelinRetraite: 0,
+    per154bis: 0,
+    total: 0,
+  };
+
+  demands.forEach((demand) => {
+    const consumed = Math.min(remaining, Math.max(0, demand.amount));
+    allocation[demand.key] = Math.round(consumed);
+    allocation.total += Math.round(consumed);
+    remaining -= consumed;
+  });
+
+  allocation.total = Math.round(allocation.total);
+  return allocation;
 }
 
 /**
  * Calcule l'assiette Madelin pour un déclarant TNS.
  */
 export function computeAssietteMadelin(d: DeclarantRevenus): number {
-  return d.bic + d.art62 +
-    d.cotisationsMadelinRetraite +
-    d.cotisationsMadelin154bis +
-    d.cotisationsPrevo;
+  return Math.round(
+    (d.bic || 0) +
+    (d.art62 || 0) +
+    (d.cotisationsMadelinRetraite || 0) +
+    (d.cotisationsMadelin154bis || 0) +
+    (d.cotisationsPrevo || 0),
+  );
 }
 
 /**
- * Vérifie si un déclarant est TNS (a des revenus BIC/BNC ou art62).
+ * Vérifie si un déclarant doit être traité comme TNS.
  */
 export function isTNS(d: DeclarantRevenus): boolean {
-  return d.bic > 0 || d.art62 > 0;
+  return d.statutTns === true;
 }
 
 /**
- * Calcule le plafond Madelin 154 bis pour un déclarant TNS.
+ * Calcule le plafond Madelin 154 bis détaillé pour un déclarant TNS.
  */
 export function computePlafondMadelin(
   params: PlafondMadelinParams,
   warnings: PerWarning[],
 ): PlafondMadelinDetail | null {
-  const { declarant, pass } = params;
+  const { declarant, pass, abat10SalCfg } = params;
+  const baseTns = Math.max(0, (declarant.bic || 0) + (declarant.art62 || 0));
 
-  if (!isTNS(declarant)) return null;
-
-  const assiette = computeAssietteMadelin(declarant);
-
-  let enveloppe15: number;
-  if (assiette <= pass) {
-    enveloppe15 = 0;
-  } else if (assiette <= 8 * pass) {
-    enveloppe15 = Math.round((assiette - pass) * 0.15);
-  } else {
-    enveloppe15 = Math.round((8 * pass - pass) * 0.15);
+  if (!isTNS(declarant)) {
+    return null;
   }
 
-  let enveloppe10: number;
-  if (assiette <= pass) {
-    enveloppe10 = Math.round(pass * 0.1);
-  } else if (assiette <= 8 * pass) {
-    enveloppe10 = Math.round(assiette * 0.1);
-  } else {
-    enveloppe10 = Math.round(8 * pass * 0.1);
+  if (baseTns <= 0) {
+    return createEmptyMadelinDetail();
   }
 
-  const potentielTotal = enveloppe15 + enveloppe10;
+  const assietteVersement = computeAssietteMadelin(declarant);
+  const assietteReport = computeAssietteReport(declarant, abat10SalCfg);
+  const enveloppe15Versement = computeEnvelope15(assietteVersement, pass);
+  const enveloppe15Report = computeEnvelope15(assietteReport, pass);
+  const enveloppe10 = computeEnvelope10(baseTns, assietteVersement, pass);
 
-  const cotisationsVersees =
-    declarant.cotisationsMadelinRetraite +
-    declarant.cotisationsMadelin154bis;
+  const madelinRetraite = Math.max(0, declarant.cotisationsMadelinRetraite || 0);
+  const per154bis = Math.max(0, declarant.cotisationsMadelin154bis || 0);
+  const art83 = Math.max(0, declarant.cotisationsArt83 || 0);
+  const perco = Math.max(0, declarant.abondementPerco || 0);
 
-  const disponibleRestant = potentielTotal - cotisationsVersees;
-  const depassement = disponibleRestant < 0;
+  const utilisation15VersementMadelin = Math.min(madelinRetraite, enveloppe15Versement);
+  const remaining15VersementAfterMadelin = Math.max(0, enveloppe15Versement - utilisation15VersementMadelin);
+  const utilisation15VersementPer154 = Math.min(per154bis, remaining15VersementAfterMadelin);
+
+  const utilisation15ReportMadelin = Math.min(madelinRetraite, enveloppe15Report);
+  const remaining15ReportAfterMadelin = Math.max(0, enveloppe15Report - utilisation15ReportMadelin);
+  const utilisation15ReportPer154 = Math.min(per154bis, remaining15ReportAfterMadelin);
+
+  const depassement15Versement = {
+    madelinRetraite: Math.max(0, madelinRetraite - enveloppe15Versement),
+    per154bis: Math.max(0, per154bis - remaining15VersementAfterMadelin),
+  };
+  const depassement15Report = {
+    madelinRetraite: Math.max(0, madelinRetraite - enveloppe15Report),
+    per154bis: Math.max(0, per154bis - remaining15ReportAfterMadelin),
+  };
+
+  const consommation10 = allocateSequentially(enveloppe10, [
+    { key: 'art83', amount: art83 },
+    { key: 'perco', amount: perco },
+    { key: 'madelinRetraite', amount: depassement15Versement.madelinRetraite },
+    { key: 'per154bis', amount: depassement15Versement.per154bis },
+  ]);
+
+  const demande10Totale =
+    art83 +
+    perco +
+    depassement15Versement.madelinRetraite +
+    depassement15Versement.per154bis;
+
+  const surplusAReintegrer = Math.max(0, Math.round(demande10Totale - consommation10.total));
+  const reste15Versement = Math.max(
+    0,
+    Math.round(enveloppe15Versement - utilisation15VersementMadelin - utilisation15VersementPer154),
+  );
+  const reste15Report = Math.max(
+    0,
+    Math.round(enveloppe15Report - utilisation15ReportMadelin - utilisation15ReportPer154),
+  );
+  const reste10 = Math.max(0, Math.round(enveloppe10 - consommation10.total));
+  const disponibleRestant = Math.max(0, Math.round(reste15Versement + reste10));
+  const depassement = surplusAReintegrer > 0;
 
   if (depassement) {
     warnings.push({
-      code: 'PER_MADELIN_DEPASSE',
-      message: `Dépassement enveloppe Madelin : versements (${cotisationsVersees.toLocaleString('fr-FR')} €) > potentiel (${potentielTotal.toLocaleString('fr-FR')} €). Réintégration fiscale à opérer.`,
+      code: 'PER_MADELIN_REINTEGRATION',
+      message: `Le dépassement des enveloppes Madelin 154 bis entraîne une réintégration fiscale de ${surplusAReintegrer.toLocaleString('fr-FR')} € dans la base TNS.`,
       severity: 'warning',
     });
   }
 
   return {
-    assiette,
-    enveloppe15,
+    assietteVersement,
+    assietteReport,
+    enveloppe15Versement,
+    enveloppe15Report,
     enveloppe10,
-    potentielTotal,
-    cotisationsVersees,
-    disponibleRestant: Math.max(0, disponibleRestant),
+    cotisationsVersees: madelinRetraite + per154bis,
+    utilisation15Versement: {
+      madelinRetraite: Math.round(utilisation15VersementMadelin),
+      per154bis: Math.round(utilisation15VersementPer154),
+      total: Math.round(utilisation15VersementMadelin + utilisation15VersementPer154),
+    },
+    depassement15Versement: {
+      madelinRetraite: Math.round(depassement15Versement.madelinRetraite),
+      per154bis: Math.round(depassement15Versement.per154bis),
+      total: Math.round(depassement15Versement.madelinRetraite + depassement15Versement.per154bis),
+    },
+    utilisation15Report: {
+      madelinRetraite: Math.round(utilisation15ReportMadelin),
+      per154bis: Math.round(utilisation15ReportPer154),
+      total: Math.round(utilisation15ReportMadelin + utilisation15ReportPer154),
+    },
+    depassement15Report: {
+      madelinRetraite: Math.round(depassement15Report.madelinRetraite),
+      per154bis: Math.round(depassement15Report.per154bis),
+      total: Math.round(depassement15Report.madelinRetraite + depassement15Report.per154bis),
+    },
+    consommation10,
+    reste15Versement,
+    reste15Report,
+    reste10,
+    disponibleRestant,
+    surplusAReintegrer,
     depassement,
   };
 }

--- a/src/engine/per/types.ts
+++ b/src/engine/per/types.ts
@@ -8,6 +8,7 @@
 // ── Entrées ──────────────────────────────────────────────────────────────────
 
 export interface DeclarantRevenus {
+  statutTns: boolean;
   salaires: number;
   fraisReels: boolean;
   fraisReelsMontant: number;
@@ -42,11 +43,13 @@ export interface SituationFiscaleInput {
 }
 
 export type PerHistoricalBasis = 'previous-avis-plus-n1' | 'current-avis';
+export type PerYearKey = 'current' | 'previous';
 
 export interface PerPotentielInput {
   mode: 'versement-n' | 'declaration-n1';
   historicalBasis: PerHistoricalBasis;
   anneeRef: number;
+  yearKey?: PerYearKey;
   situationFiscale: SituationFiscaleInput;
   projectionFiscale?: SituationFiscaleInput;
   avisIr?: AvisIrPlafonds;
@@ -72,12 +75,44 @@ export interface PlafondDetail {
 }
 
 export interface PlafondMadelinDetail {
-  assiette: number;
-  enveloppe15: number;
+  assietteVersement: number;
+  assietteReport: number;
+  enveloppe15Versement: number;
+  enveloppe15Report: number;
   enveloppe10: number;
-  potentielTotal: number;
   cotisationsVersees: number;
+  utilisation15Versement: {
+    madelinRetraite: number;
+    per154bis: number;
+    total: number;
+  };
+  depassement15Versement: {
+    madelinRetraite: number;
+    per154bis: number;
+    total: number;
+  };
+  utilisation15Report: {
+    madelinRetraite: number;
+    per154bis: number;
+    total: number;
+  };
+  depassement15Report: {
+    madelinRetraite: number;
+    per154bis: number;
+    total: number;
+  };
+  consommation10: {
+    art83: number;
+    perco: number;
+    madelinRetraite: number;
+    per154bis: number;
+    total: number;
+  };
+  reste15Versement: number;
+  reste15Report: number;
+  reste10: number;
   disponibleRestant: number;
+  surplusAReintegrer: number;
   depassement: boolean;
 }
 
@@ -112,12 +147,42 @@ export interface Declaration2042Boxes {
   case6QR: boolean;
 }
 
+export interface PerDeductionDetail {
+  plafondDisponible: number;
+  plafondApresMutualisation: number;
+  cotisationsVersees: number;
+  cotisationsRetenuesIr: number;
+  cotisationsNonDeductibles: number;
+  mutualisationRecue: number;
+  mutualisationCedee: number;
+  disponibleRestant: number;
+}
+
+export interface PerDeductionFlow {
+  declarant1: PerDeductionDetail;
+  declarant2?: PerDeductionDetail;
+  totalDeductionsIr: number;
+}
+
+export interface PerProjectionAvisDetail {
+  nonUtiliseN2: number;
+  nonUtiliseN1: number;
+  nonUtiliseN: number;
+  plafondCalculeN: number;
+  plafondTotal: number;
+}
+
 export interface PerPotentielResult {
   situationFiscale: SituationFiscaleResult;
   plafond163Q: { declarant1: PlafondDetail; declarant2?: PlafondDetail };
+  deductionFlow163Q: PerDeductionFlow;
   plafondMadelin?: { declarant1: PlafondMadelinDetail; declarant2?: PlafondMadelinDetail };
   estTNS: boolean;
   declaration2042: Declaration2042Boxes;
+  projectionAvisSuivant: {
+    declarant1: PerProjectionAvisDetail;
+    declarant2?: PerProjectionAvisDetail;
+  };
   simulation?: SimulationVersement;
   warnings: PerWarning[];
 }

--- a/src/features/per/__tests__/perPotentielExport.test.ts
+++ b/src/features/per/__tests__/perPotentielExport.test.ts
@@ -10,6 +10,7 @@ const THEME_COLORS = DEFAULT_COLORS;
 
 function makeDeclarant(overrides: Record<string, number | boolean> = {}) {
   return {
+    statutTns: false,
     salaires: 0,
     fraisReels: false,
     fraisReelsMontant: 0,
@@ -78,7 +79,7 @@ describe('PER Potentiel PPTX Export', () => {
     ).toBe(true);
     expect(
       spec.slides.some(
-        (slide) => slide.type === 'content' && 'title' in slide && slide.title === 'Impact du versement',
+        (slide) => slide.type === 'content' && 'title' in slide && slide.title === 'Projection du prochain avis IR',
       ),
     ).toBe(true);
   });

--- a/src/features/per/components/potentiel/PerAmountInput.tsx
+++ b/src/features/per/components/potentiel/PerAmountInput.tsx
@@ -9,6 +9,7 @@ interface PerAmountInputProps {
   placeholder?: string;
   min?: number;
   className?: string;
+  disabled?: boolean;
 }
 
 
@@ -26,6 +27,7 @@ export function PerAmountInput({
   placeholder = '0',
   min = 0,
   className = '',
+  disabled = false,
 }: PerAmountInputProps) {
   const [raw, setRaw] = useState<string | null>(null);
   const isFocused = raw !== null;
@@ -60,6 +62,7 @@ export function PerAmountInput({
       value={displayValue}
       aria-label={ariaLabel}
       placeholder={placeholder}
+      disabled={disabled}
       onFocus={handleFocus}
       onBlur={handleBlur}
       onChange={handleChange}

--- a/src/features/per/components/potentiel/PerMadelinInfoModal.test.tsx
+++ b/src/features/per/components/potentiel/PerMadelinInfoModal.test.tsx
@@ -1,0 +1,39 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { PerMadelinInfoModal } from './PerMadelinInfoModal';
+
+const zeroDetail = {
+  assietteVersement: 0,
+  assietteReport: 0,
+  enveloppe15Versement: 0,
+  enveloppe15Report: 0,
+  enveloppe10: 0,
+  cotisationsVersees: 0,
+  utilisation15Versement: { madelinRetraite: 0, per154bis: 0, total: 0 },
+  depassement15Versement: { madelinRetraite: 0, per154bis: 0, total: 0 },
+  utilisation15Report: { madelinRetraite: 0, per154bis: 0, total: 0 },
+  depassement15Report: { madelinRetraite: 0, per154bis: 0, total: 0 },
+  consommation10: { art83: 0, perco: 0, madelinRetraite: 0, per154bis: 0, total: 0 },
+  reste15Versement: 0,
+  reste15Report: 0,
+  reste10: 0,
+  disponibleRestant: 0,
+  surplusAReintegrer: 0,
+  depassement: false,
+};
+
+describe('PerMadelinInfoModal', () => {
+  it('affiche les lignes de détail même avec une base TNS non saisie', () => {
+    const html = renderToStaticMarkup(
+      <PerMadelinInfoModal
+        declarant1={zeroDetail}
+        isCouple={false}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('Aucune base TNS saisie');
+    expect(html).toContain('Assiette de versement');
+    expect(html).toContain('Enveloppe 10 % commune');
+  });
+});

--- a/src/features/per/components/potentiel/PerMadelinInfoModal.tsx
+++ b/src/features/per/components/potentiel/PerMadelinInfoModal.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { SimModalShell } from '@/components/ui/sim';
+import type { PlafondMadelinDetail } from '../../../../engine/per';
+
+interface PerMadelinInfoModalProps {
+  declarant1?: PlafondMadelinDetail;
+  declarant2?: PlafondMadelinDetail;
+  isCouple: boolean;
+  onClose: () => void;
+}
+
+const fmtCurrency = (value: number): string =>
+  new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  }).format(value);
+
+function MadelinDetailCard({
+  label,
+  detail,
+}: {
+  label: string;
+  detail?: PlafondMadelinDetail;
+}): React.ReactElement | null {
+  if (!detail) {
+    return null;
+  }
+
+  const showHint = detail.assietteVersement <= 0 && detail.cotisationsVersees <= 0;
+
+  const rows = [
+    ['Assiette de versement', detail.assietteVersement],
+    ['Assiette de report 2042', detail.assietteReport],
+    ['Enveloppe 15 % de versement', detail.enveloppe15Versement],
+    ['Enveloppe 15 % de report 2042', detail.enveloppe15Report],
+    ['Enveloppe 10 % commune', detail.enveloppe10],
+    ['Consommation 10 % Art. 83', detail.consommation10.art83],
+    ['Consommation 10 % PERCO / PERECO', detail.consommation10.perco],
+    ['Consommation 10 % Madelin retraite', detail.consommation10.madelinRetraite],
+    ['Consommation 10 % PER 154 bis', detail.consommation10.per154bis],
+    ['Reste enveloppe 15 % versement', detail.reste15Versement],
+    ['Reste enveloppe 15 % report', detail.reste15Report],
+    ['Reste enveloppe 10 %', detail.reste10],
+    ['Réintégration à opérer', detail.surplusAReintegrer],
+  ];
+
+  return (
+    <div className="premium-card-compact per-madelin-modal-card">
+      <div className="per-summary-card-head">
+        <p className="premium-section-title">PER 154 bis</p>
+        <h4 className="per-summary-card-title">{label}</h4>
+      </div>
+
+      <div className="per-summary-breakdown-list">
+        {showHint && (
+          <div className="per-summary-breakdown-row per-summary-breakdown-row--muted">
+            <span>Aucune base TNS saisie</span>
+            <strong>0 €</strong>
+          </div>
+        )}
+        {rows.map(([rowLabel, value]) => (
+          <div key={rowLabel} className="per-summary-breakdown-row">
+            <span>{rowLabel}</span>
+            <strong>{fmtCurrency(Number(value))}</strong>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function PerMadelinInfoModal({
+  declarant1,
+  declarant2,
+  isCouple,
+  onClose,
+}: PerMadelinInfoModalProps): React.ReactElement {
+  return (
+    <SimModalShell
+      title="Détail du calcul Madelin 154 bis"
+      subtitle="Lecture des enveloppes 15 % et 10 % communes, telle qu'utilisée par le moteur PER."
+      onClose={onClose}
+      modalClassName="per-madelin-modal"
+      bodyClassName="per-madelin-modal__body"
+    >
+      <div className={`per-summary-breakdown-grid ${isCouple ? 'is-couple' : ''}`}>
+        <MadelinDetailCard label="Déclarant 1" detail={declarant1} />
+        {isCouple && <MadelinDetailCard label="Déclarant 2" detail={declarant2} />}
+      </div>
+    </SimModalShell>
+  );
+}

--- a/src/features/per/components/potentiel/PerPotentielContextSidebar.test.tsx
+++ b/src/features/per/components/potentiel/PerPotentielContextSidebar.test.tsx
@@ -1,0 +1,183 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import type { PerPotentielResult } from '../../../../engine/per';
+import { PerPotentielContextSidebar } from './PerPotentielContextSidebar';
+
+const fmtCurrency = (value: number): string =>
+  new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  }).format(value);
+
+const result: PerPotentielResult = {
+  situationFiscale: {
+    revenuImposableD1: 32000,
+    revenuImposableD2: 28000,
+    revenuFiscalRef: 60000,
+    tmi: 0.3,
+    irEstime: 5400,
+    decote: 0,
+    cehr: 0,
+    montantDansLaTMI: 1200,
+  },
+  plafond163Q: {
+    declarant1: {
+      plafondCalculeN: 0,
+      nonUtiliseN1: 0,
+      nonUtiliseN2: 0,
+      nonUtiliseN3: 0,
+      totalDisponible: 0,
+      cotisationsDejaVersees: 0,
+      disponibleRestant: 0,
+      depassement: false,
+    },
+    declarant2: {
+      plafondCalculeN: 0,
+      nonUtiliseN1: 0,
+      nonUtiliseN2: 0,
+      nonUtiliseN3: 0,
+      totalDisponible: 0,
+      cotisationsDejaVersees: 0,
+      disponibleRestant: 0,
+      depassement: false,
+    },
+  },
+  deductionFlow163Q: {
+    declarant1: {
+      plafondDisponible: 11111,
+      plafondApresMutualisation: 11111,
+      cotisationsVersees: 4568,
+      cotisationsRetenuesIr: 4568,
+      cotisationsNonDeductibles: 0,
+      mutualisationRecue: 0,
+      mutualisationCedee: 0,
+      disponibleRestant: 6543,
+    },
+    declarant2: {
+      plafondDisponible: 7777,
+      plafondApresMutualisation: 7777,
+      cotisationsVersees: 4567,
+      cotisationsRetenuesIr: 4567,
+      cotisationsNonDeductibles: 0,
+      mutualisationRecue: 0,
+      mutualisationCedee: 0,
+      disponibleRestant: 3210,
+    },
+    totalDeductionsIr: 9135,
+  },
+  plafondMadelin: {
+    declarant1: {
+      assietteVersement: 0,
+      assietteReport: 0,
+      enveloppe15Versement: 0,
+      enveloppe15Report: 0,
+      enveloppe10: 0,
+      cotisationsVersees: 0,
+      utilisation15Versement: { madelinRetraite: 0, per154bis: 0, total: 0 },
+      depassement15Versement: { madelinRetraite: 0, per154bis: 0, total: 0 },
+      utilisation15Report: { madelinRetraite: 0, per154bis: 0, total: 0 },
+      depassement15Report: { madelinRetraite: 0, per154bis: 0, total: 0 },
+      consommation10: { art83: 0, perco: 0, madelinRetraite: 0, per154bis: 0, total: 0 },
+      reste15Versement: 0,
+      reste15Report: 0,
+      reste10: 0,
+      disponibleRestant: 0,
+      surplusAReintegrer: 0,
+      depassement: false,
+    },
+    declarant2: {
+      assietteVersement: 0,
+      assietteReport: 0,
+      enveloppe15Versement: 0,
+      enveloppe15Report: 0,
+      enveloppe10: 0,
+      cotisationsVersees: 0,
+      utilisation15Versement: { madelinRetraite: 0, per154bis: 0, total: 0 },
+      depassement15Versement: { madelinRetraite: 0, per154bis: 0, total: 0 },
+      utilisation15Report: { madelinRetraite: 0, per154bis: 0, total: 0 },
+      depassement15Report: { madelinRetraite: 0, per154bis: 0, total: 0 },
+      consommation10: { art83: 0, perco: 0, madelinRetraite: 0, per154bis: 0, total: 0 },
+      reste15Versement: 0,
+      reste15Report: 0,
+      reste10: 0,
+      disponibleRestant: 0,
+      surplusAReintegrer: 0,
+      depassement: false,
+    },
+  },
+  estTNS: false,
+  declaration2042: {
+    case6NS: 1200,
+    case6NT: 1300,
+    case6RS: 900,
+    case6RT: 800,
+    case6QS: 700,
+    case6QT: 600,
+    case6OS: 500,
+    case6OT: 400,
+    case6QR: true,
+  },
+  projectionAvisSuivant: {
+    declarant1: {
+      nonUtiliseN2: 2100,
+      nonUtiliseN1: 2200,
+      nonUtiliseN: 2300,
+      plafondCalculeN: 2400,
+      plafondTotal: 9000,
+    },
+    declarant2: {
+      nonUtiliseN2: 1100,
+      nonUtiliseN1: 1200,
+      nonUtiliseN: 1300,
+      plafondCalculeN: 1400,
+      plafondTotal: 5000,
+    },
+  },
+  warnings: [],
+};
+
+describe('PerPotentielContextSidebar', () => {
+  it('uses the remaining 163 quatervicies and a single live preview on the revenus step', () => {
+    const html = renderToStaticMarkup(
+      <PerPotentielContextSidebar
+        step={3}
+        isCouple
+        showRevenusPreview
+        parcoursPills={[{ label: 'Avis IR 2025', on: true }]}
+        totalAvisIrD1={11111}
+        totalAvisIrD2={7777}
+        result={result}
+      />,
+    );
+
+    expect(html).toContain('163 quatervicies disponible après saisie');
+    expect(html).toContain(fmtCurrency(6543));
+    expect(html).toContain(fmtCurrency(3210));
+    expect(html).not.toContain(fmtCurrency(11111));
+    expect(html).toContain('Déclaration 2042');
+    expect(html).toContain('Prochain avis IR');
+    expect(html).toContain('6NS');
+    expect(html).toContain('6NT');
+    expect(html).toContain('Déclarant 1');
+    expect(html).toContain('Déclarant 2');
+    expect((html.match(/Aperçu en direct/g) ?? []).length).toBe(1);
+  });
+
+  it('keeps the split live preview outside the revenus step', () => {
+    const html = renderToStaticMarkup(
+      <PerPotentielContextSidebar
+        step={3}
+        isCouple
+        showRevenusPreview={false}
+        parcoursPills={[{ label: 'Avis IR 2025', on: true }]}
+        totalAvisIrD1={11111}
+        totalAvisIrD2={7777}
+        result={result}
+      />,
+    );
+
+    expect((html.match(/Aperçu en direct/g) ?? []).length).toBe(2);
+    expect(html).toContain(fmtCurrency(11111));
+  });
+});

--- a/src/features/per/components/potentiel/PerPotentielContextSidebar.tsx
+++ b/src/features/per/components/potentiel/PerPotentielContextSidebar.tsx
@@ -1,0 +1,318 @@
+import React from 'react';
+import type { PerPotentielResult } from '../../../../engine/per';
+import type { WizardStep } from '../../hooks/usePerPotentiel';
+
+interface PerPotentielContextSidebarProps {
+  step: WizardStep;
+  isCouple: boolean;
+  showRevenusPreview: boolean;
+  parcoursPills: Array<{ label: string; on: boolean }>;
+  totalAvisIrD1: number;
+  totalAvisIrD2: number;
+  result: PerPotentielResult | null;
+}
+
+const fmtCurrency = (value: number): string =>
+  new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  }).format(value);
+
+const fmtPercent = (value: number): string =>
+  `${(value <= 1 ? value * 100 : value).toFixed(1)} %`;
+
+function MiniKpi({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}): React.ReactElement {
+  return (
+    <div className="per-potentiel-mini-kpi">
+      <span className="per-potentiel-mini-kpi-label">{label}</span>
+      <strong className="per-potentiel-mini-kpi-value">{value}</strong>
+    </div>
+  );
+}
+
+function PreviewColumn({
+  title,
+  items,
+}: {
+  title: string;
+  items: Array<{ label: string; value: string }>;
+}): React.ReactElement {
+  return (
+    <div className="per-potentiel-preview-column">
+      <div className="per-potentiel-preview-column__title">{title}</div>
+      <div className="per-potentiel-mini-kpis">
+        {items.map((item) => (
+          <MiniKpi key={`${title}-${item.label}`} label={item.label} value={item.value} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function PerPotentielContextSidebar({
+  step,
+  isCouple,
+  showRevenusPreview,
+  parcoursPills,
+  totalAvisIrD1,
+  totalAvisIrD2,
+  result,
+}: PerPotentielContextSidebarProps): React.ReactElement {
+  const showPotentielAvis = step <= 3;
+  const showLivePreview = Boolean(result && step !== 5);
+  const potentielD1 = showRevenusPreview && result
+    ? result.deductionFlow163Q.declarant1.disponibleRestant
+    : totalAvisIrD1;
+  const potentielD2 = showRevenusPreview && result
+    ? result.deductionFlow163Q.declarant2?.disponibleRestant ?? totalAvisIrD2
+    : totalAvisIrD2;
+  const potentielLabel = showRevenusPreview
+    ? '163 quatervicies disponible après saisie'
+    : "163 quatervicies issu de l'avis IR";
+
+  const declarationD1 = result
+    ? [
+      { label: '6NS', value: fmtCurrency(result.declaration2042.case6NS) },
+      { label: '6RS', value: fmtCurrency(result.declaration2042.case6RS) },
+      { label: '6OS', value: fmtCurrency(result.declaration2042.case6OS) },
+      { label: '6QS', value: fmtCurrency(result.declaration2042.case6QS) },
+    ]
+    : [];
+  const declarationD2 = result
+    ? [
+      { label: '6NT', value: fmtCurrency(result.declaration2042.case6NT ?? 0) },
+      { label: '6RT', value: fmtCurrency(result.declaration2042.case6RT ?? 0) },
+      { label: '6OT', value: fmtCurrency(result.declaration2042.case6OT ?? 0) },
+      { label: '6QT', value: fmtCurrency(result.declaration2042.case6QT ?? 0) },
+    ]
+    : [];
+  const projectionD1 = result
+    ? [
+      { label: 'Reliquat N-2', value: fmtCurrency(result.projectionAvisSuivant.declarant1.nonUtiliseN2) },
+      { label: 'Reliquat N-1', value: fmtCurrency(result.projectionAvisSuivant.declarant1.nonUtiliseN1) },
+      { label: 'Reliquat N', value: fmtCurrency(result.projectionAvisSuivant.declarant1.nonUtiliseN) },
+      { label: 'Plafond calculé', value: fmtCurrency(result.projectionAvisSuivant.declarant1.plafondCalculeN) },
+      { label: 'Total', value: fmtCurrency(result.projectionAvisSuivant.declarant1.plafondTotal) },
+    ]
+    : [];
+  const projectionD2 = result?.projectionAvisSuivant.declarant2
+    ? [
+      { label: 'Reliquat N-2', value: fmtCurrency(result.projectionAvisSuivant.declarant2.nonUtiliseN2) },
+      { label: 'Reliquat N-1', value: fmtCurrency(result.projectionAvisSuivant.declarant2.nonUtiliseN1) },
+      { label: 'Reliquat N', value: fmtCurrency(result.projectionAvisSuivant.declarant2.nonUtiliseN) },
+      { label: 'Plafond calculé', value: fmtCurrency(result.projectionAvisSuivant.declarant2.plafondCalculeN) },
+      { label: 'Total', value: fmtCurrency(result.projectionAvisSuivant.declarant2.plafondTotal) },
+    ]
+    : [];
+
+  return (
+    <>
+      <div className="premium-card per-potentiel-context-card sim-summary-card">
+        <div className="sim-card__title-row">
+          <div className="sim-card__icon">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M21.21 15.89A10 10 0 1 1 8 2.83" />
+              <path d="M22 12A10 10 0 0 0 12 2v10z" />
+            </svg>
+          </div>
+          <h3 className="sim-card__title">Potentiel</h3>
+        </div>
+        <div className="sim-divider" />
+        <div className="per-potentiel-context-list">
+          {parcoursPills.length > 0 && (
+            <div className="per-potentiel-context-item">
+              <span className="per-potentiel-context-label per-potentiel-context-label--small">Parcours</span>
+              <div className="per-potentiel-pills">
+                {parcoursPills.map((pill) => (
+                  <span key={pill.label} className={`per-potentiel-pill${pill.on ? ' is-on' : ''}`}>
+                    {pill.label}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {parcoursPills.length > 0 && showPotentielAvis && <div className="sim-divider sim-divider--tight" />}
+
+          {showPotentielAvis && (
+            <div className="per-potentiel-context-item per-potentiel-context-item--avis">
+              <span className="per-potentiel-context-label per-potentiel-context-label--small">{potentielLabel}</span>
+              <div className="per-potentiel-mini-kpis per-potentiel-mini-kpis--avis">
+                <MiniKpi label="Déclarant 1" value={fmtCurrency(potentielD1)} />
+                {(isCouple || potentielD2 > 0) && (
+                  <MiniKpi label="Déclarant 2" value={fmtCurrency(potentielD2)} />
+                )}
+              </div>
+            </div>
+          )}
+
+          {result?.plafondMadelin && (
+            <div className="per-potentiel-context-item">
+              <span className="per-potentiel-context-label per-potentiel-context-label--small">Enveloppes Madelin N</span>
+              <div className="per-potentiel-mini-kpis">
+                <MiniKpi
+                  label="D1 15 %"
+                  value={fmtCurrency(result.plafondMadelin.declarant1.enveloppe15Versement)}
+                />
+                <MiniKpi
+                  label="D1 10 %"
+                  value={fmtCurrency(result.plafondMadelin.declarant1.enveloppe10)}
+                />
+                {isCouple && result.plafondMadelin.declarant2 && (
+                  <>
+                    <MiniKpi
+                      label="D2 15 %"
+                      value={fmtCurrency(result.plafondMadelin.declarant2.enveloppe15Versement)}
+                    />
+                    <MiniKpi
+                      label="D2 10 %"
+                      value={fmtCurrency(result.plafondMadelin.declarant2.enveloppe10)}
+                    />
+                  </>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {showLivePreview && result && (
+        <>
+          {showRevenusPreview ? (
+            <div className="premium-card per-potentiel-context-card sim-summary-card sim-summary-card--secondary">
+              <div className="sim-card__title-row">
+                <div className="sim-card__icon">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <line x1="12" y1="20" x2="12" y2="10" />
+                    <line x1="18" y1="20" x2="18" y2="4" />
+                    <line x1="6" y1="20" x2="6" y2="16" />
+                  </svg>
+                </div>
+                <h3 className="sim-card__title">Aperçu en direct</h3>
+              </div>
+              <div className="sim-divider sim-divider--tight" />
+
+              <div className="per-sidebar-hero">
+                <div className="per-sidebar-hero__left">
+                  <div className="per-sidebar-hero__label">IR estimé</div>
+                  <div className="per-sidebar-hero__value">{fmtCurrency(result.situationFiscale.irEstime)}</div>
+                </div>
+                <div className="per-potentiel-mini-kpis-row">
+                  <MiniKpi label="TMI" value={fmtPercent(result.situationFiscale.tmi)} />
+                  <MiniKpi label="6QR" value={result.declaration2042.case6QR ? 'Oui' : 'Non'} />
+                </div>
+              </div>
+
+              <div className="sim-divider sim-divider--tight" />
+              <div className="per-potentiel-preview-section">
+                <div className="per-potentiel-context-section__title">Déclaration 2042</div>
+                <div className={`per-potentiel-preview-columns${isCouple ? ' is-couple' : ''}`}>
+                  <PreviewColumn title="Déclarant 1" items={declarationD1} />
+                  {isCouple && <PreviewColumn title="Déclarant 2" items={declarationD2} />}
+                </div>
+              </div>
+
+              <div className="sim-divider sim-divider--tight" />
+              <div className="per-potentiel-preview-section">
+                <div className="per-potentiel-context-section__title">Prochain avis IR</div>
+                <div className={`per-potentiel-preview-columns${isCouple && projectionD2.length > 0 ? ' is-couple' : ''}`}>
+                  <PreviewColumn title="Déclarant 1" items={projectionD1} />
+                  {isCouple && projectionD2.length > 0 && (
+                    <PreviewColumn title="Déclarant 2" items={projectionD2} />
+                  )}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <>
+              <div className="premium-card per-potentiel-context-card sim-summary-card sim-summary-card--secondary">
+                <div className="sim-card__title-row">
+                  <div className="sim-card__icon">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                      <line x1="12" y1="20" x2="12" y2="10" />
+                      <line x1="18" y1="20" x2="18" y2="4" />
+                      <line x1="6" y1="20" x2="6" y2="16" />
+                    </svg>
+                  </div>
+                  <h3 className="sim-card__title">Aperçu en direct</h3>
+                </div>
+                <div className="sim-divider sim-divider--tight" />
+
+                <div className="per-sidebar-hero">
+                  <div className="per-sidebar-hero__left">
+                    <div className="per-sidebar-hero__label">IR estimé</div>
+                    <div className="per-sidebar-hero__value">{fmtCurrency(result.situationFiscale.irEstime)}</div>
+                  </div>
+                  <div className="per-potentiel-mini-kpis">
+                    <MiniKpi label="TMI" value={fmtPercent(result.situationFiscale.tmi)} />
+                    <MiniKpi label="6QR" value={result.declaration2042.case6QR ? 'Oui' : 'Non'} />
+                  </div>
+                </div>
+
+                <div className="sim-divider sim-divider--tight" />
+                <div className="per-potentiel-context-section">
+                  <div className="per-potentiel-context-section__title">Déclaration 2042</div>
+                  <div className="per-potentiel-mini-kpis">
+                    <MiniKpi label="D1 6NS" value={fmtCurrency(result.declaration2042.case6NS)} />
+                    <MiniKpi label="D1 6RS" value={fmtCurrency(result.declaration2042.case6RS)} />
+                    <MiniKpi label="D1 6OS" value={fmtCurrency(result.declaration2042.case6OS)} />
+                    <MiniKpi label="D1 6QS" value={fmtCurrency(result.declaration2042.case6QS)} />
+                    {isCouple && typeof result.declaration2042.case6NT === 'number' && (
+                      <>
+                        <MiniKpi label="D2 6NT" value={fmtCurrency(result.declaration2042.case6NT)} />
+                        <MiniKpi label="D2 6RT" value={fmtCurrency(result.declaration2042.case6RT ?? 0)} />
+                        <MiniKpi label="D2 6OT" value={fmtCurrency(result.declaration2042.case6OT ?? 0)} />
+                        <MiniKpi label="D2 6QT" value={fmtCurrency(result.declaration2042.case6QT ?? 0)} />
+                      </>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              <div className="premium-card per-potentiel-context-card sim-summary-card sim-summary-card--secondary">
+                <div className="sim-card__title-row">
+                  <div className="sim-card__icon">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                      <path d="M3 7h18" />
+                      <path d="M6 11h12" />
+                      <path d="M8 15h8" />
+                      <path d="M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Z" />
+                    </svg>
+                  </div>
+                  <h3 className="sim-card__title">Aperçu en direct</h3>
+                </div>
+                <div className="sim-divider sim-divider--tight" />
+                <div className="per-potentiel-context-section">
+                  <div className="per-potentiel-context-section__title">Prochain avis IR</div>
+                  <div className="per-potentiel-mini-kpis">
+                    <MiniKpi label="D1 reliquat N-2" value={fmtCurrency(result.projectionAvisSuivant.declarant1.nonUtiliseN2)} />
+                    <MiniKpi label="D1 reliquat N-1" value={fmtCurrency(result.projectionAvisSuivant.declarant1.nonUtiliseN1)} />
+                    <MiniKpi label="D1 reliquat N" value={fmtCurrency(result.projectionAvisSuivant.declarant1.nonUtiliseN)} />
+                    <MiniKpi label="D1 plafond calculé" value={fmtCurrency(result.projectionAvisSuivant.declarant1.plafondCalculeN)} />
+                    <MiniKpi label="D1 total" value={fmtCurrency(result.projectionAvisSuivant.declarant1.plafondTotal)} />
+                    {isCouple && result.projectionAvisSuivant.declarant2 && (
+                      <>
+                        <MiniKpi label="D2 reliquat N-2" value={fmtCurrency(result.projectionAvisSuivant.declarant2.nonUtiliseN2)} />
+                        <MiniKpi label="D2 reliquat N-1" value={fmtCurrency(result.projectionAvisSuivant.declarant2.nonUtiliseN1)} />
+                        <MiniKpi label="D2 reliquat N" value={fmtCurrency(result.projectionAvisSuivant.declarant2.nonUtiliseN)} />
+                        <MiniKpi label="D2 plafond calculé" value={fmtCurrency(result.projectionAvisSuivant.declarant2.plafondCalculeN)} />
+                        <MiniKpi label="D2 total" value={fmtCurrency(result.projectionAvisSuivant.declarant2.plafondTotal)} />
+                      </>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </>
+  );
+}

--- a/src/features/per/components/potentiel/PerPotentielSimulator.test.tsx
+++ b/src/features/per/components/potentiel/PerPotentielSimulator.test.tsx
@@ -81,18 +81,21 @@ vi.mock('./PerHypotheses', () => ({
   PerHypotheses: () => <div>Hypothèses</div>,
 }));
 
+vi.mock('./PerPotentielContextSidebar', () => ({
+  PerPotentielContextSidebar: ({
+    totalAvisIrD1,
+    totalAvisIrD2,
+  }: {
+    totalAvisIrD1: number;
+    totalAvisIrD2: number;
+  }) => <div>Sidebar contexte {totalAvisIrD1} / {totalAvisIrD2}</div>,
+}));
+
 vi.mock('./PerSynthesisSidebar', () => ({
   PerSynthesisSidebar: () => <div>Sidebar finale</div>,
 }));
 
 import PerPotentielSimulator from './PerPotentielSimulator';
-
-const fmtCurrency = (value: number): string =>
-  new Intl.NumberFormat('fr-FR', {
-    style: 'currency',
-    currency: 'EUR',
-    maximumFractionDigits: 0,
-  }).format(value);
 
 function makeHookState(step: number) {
   return {
@@ -118,10 +121,10 @@ function makeHookState(step: number) {
     nombreParts: 1,
     isole: false,
     children: [],
-    revenusN1Declarant1: {},
-    revenusN1Declarant2: {},
-    projectionNDeclarant1: {},
-    projectionNDeclarant2: {},
+    revenusN1Declarant1: { statutTns: false },
+    revenusN1Declarant2: { statutTns: false },
+    projectionNDeclarant1: { statutTns: false },
+    projectionNDeclarant2: { statutTns: false },
     versementEnvisage: 0,
     mutualisationConjoints: false,
   };
@@ -137,10 +140,33 @@ function makeHookReturn(step: number) {
           irEstime: 1000,
           revenuImposableD1: 20000,
           revenuImposableD2: 0,
+          revenuFiscalRef: 20000,
+          decote: 0,
+          cehr: 0,
+          montantDansLaTMI: 1000,
         },
         plafond163Q: {
-          declarant1: { disponibleRestant: 6000 },
+          declarant1: { disponibleRestant: 6000, totalDisponible: 11000 },
           declarant2: undefined,
+        },
+        deductionFlow163Q: {
+          declarant1: { disponibleRestant: 6000, plafondDisponible: 11000 },
+        },
+        declaration2042: {
+          case6NS: 1000,
+          case6RS: 0,
+          case6QS: 0,
+          case6OS: 0,
+          case6QR: false,
+        },
+        projectionAvisSuivant: {
+          declarant1: {
+            nonUtiliseN2: 2000,
+            nonUtiliseN1: 3000,
+            nonUtiliseN: 1000,
+            plafondCalculeN: 4000,
+            plafondTotal: 10000,
+          },
         },
       }
       : null,
@@ -174,9 +200,7 @@ describe('PerPotentielSimulator', () => {
     const html = renderToStaticMarkup(<PerPotentielSimulator />);
 
     expect(html).toContain('Avis step 11000 / 7000');
-    expect(html).toContain('Potentiel 163 quatervicies');
-    expect(html).toContain(fmtCurrency(11000));
-    expect(html).toContain(fmtCurrency(7000));
+    expect(html).toContain('Sidebar contexte 11000 / 7000');
   });
 
   it('keeps the avis totals visible in the right sidebar on step 3', () => {
@@ -184,19 +208,15 @@ describe('PerPotentielSimulator', () => {
 
     const html = renderToStaticMarkup(<PerPotentielSimulator />);
 
-    expect(html).toContain('Potentiel 163 quatervicies');
-    expect(html).toContain(fmtCurrency(11000));
-    expect(html).toContain(fmtCurrency(7000));
+    expect(html).toContain('Sidebar contexte 11000 / 7000');
   });
 
-  it('shows nombre de parts next to the TMI in the live preview', () => {
+  it('keeps the context sidebar active on step 3', () => {
     mockUsePerPotentiel.mockReturnValue(makeHookReturn(3));
 
     const html = renderToStaticMarkup(<PerPotentielSimulator />);
 
-    expect(html).toContain('Nombre de parts');
-    expect(html).toContain('1');
-    expect(html).toContain('TMI');
+    expect(html).toContain('Sidebar contexte 11000 / 7000');
   });
 
   it('hides the avis totals once the simulator reaches step 4', () => {
@@ -212,7 +232,7 @@ describe('PerPotentielSimulator', () => {
 
     const html = renderToStaticMarkup(<PerPotentielSimulator />);
 
-    expect(html).not.toContain('Potentiel 163 quatervicies');
+    expect(html).toContain('Sidebar contexte 11000 / 7000');
   });
 
   it('uses the shared title row pattern for stage headers', () => {

--- a/src/features/per/components/potentiel/PerPotentielSimulator.tsx
+++ b/src/features/per/components/potentiel/PerPotentielSimulator.tsx
@@ -20,6 +20,7 @@ import SituationFiscaleStep from './steps/SituationFiscaleStep';
 import SynthesePotentielStep from './steps/SynthesePotentielStep';
 import type { PerAbattementConfig, PerIncomeFilters } from './steps/PerIncomeTable';
 import { PerHypotheses } from './PerHypotheses';
+import { PerPotentielContextSidebar } from './PerPotentielContextSidebar';
 import { PerSynthesisSidebar } from './PerSynthesisSidebar';
 import '../../styles/index.css';
 
@@ -27,16 +28,6 @@ type StepMeta = {
   shortLabel: string;
   title: string;
 };
-
-const fmtCurrency = (value: number): string =>
-  new Intl.NumberFormat('fr-FR', {
-    style: 'currency',
-    currency: 'EUR',
-    maximumFractionDigits: 0,
-  }).format(value);
-
-const fmtPercent = (value: number): string =>
-  `${(value <= 1 ? value * 100 : value).toFixed(1)} %`;
 
 const sumAvisIrPlafonds = (
   avis: {
@@ -52,7 +43,6 @@ const sumAvisIrPlafonds = (
   + (avis?.plafondCalcule ?? 0);
 
 const DEFAULT_INCOME_FILTERS: PerIncomeFilters = {
-  tns: false,
   pension: false,
   foncier: false,
 };
@@ -203,10 +193,13 @@ export default function PerPotentielSimulator(): React.ReactElement {
   const totalAvisIrD1 = sumAvisIrPlafonds(state.avisIr);
   const totalAvisIrD2 = sumAvisIrPlafonds(state.avisIr2);
   const abat10CfgRoot = fiscalContext._raw_tax?.incomeTax?.abat10 ?? {};
-  const abat10SalCfgPrevious: PerAbattementConfig = abat10CfgRoot.previous ?? {};
   const abat10SalCfgCurrent: PerAbattementConfig = abat10CfgRoot.current ?? {};
-  const abat10RetCfgPrevious: PerAbattementConfig = abat10CfgRoot.retireesPrevious ?? {};
   const abat10RetCfgCurrent: PerAbattementConfig = abat10CfgRoot.retireesCurrent ?? {};
+  const isRevenusStep = state.step === 3
+    && (
+      state.mode === 'declaration-n1'
+      || (state.mode === 'versement-n' && state.historicalBasis === 'previous-avis-plus-n1')
+    );
 
   const avisBasis = state.mode === 'declaration-n1'
     ? 'previous-avis-plus-n1'
@@ -310,8 +303,9 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   declarant1={state.revenusN1Declarant1}
                   declarant2={state.revenusN1Declarant2}
                   incomeFilters={incomeFilters}
-                  abat10SalCfg={abat10SalCfgPrevious}
-                  abat10RetCfg={abat10RetCfgPrevious}
+                  plafondMadelin={result?.plafondMadelin}
+                  abat10SalCfg={abat10SalCfgCurrent}
+                  abat10RetCfg={abat10RetCfgCurrent}
                   onUpdateSituation={updateSituation}
                   onAddChild={addChild}
                   onUpdateChildMode={updateChildMode}
@@ -334,8 +328,9 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   declarant1={state.revenusN1Declarant1}
                   declarant2={state.revenusN1Declarant2}
                   incomeFilters={incomeFilters}
-                  abat10SalCfg={abat10SalCfgPrevious}
-                  abat10RetCfg={abat10RetCfgPrevious}
+                  plafondMadelin={result?.plafondMadelin}
+                  abat10SalCfg={abat10SalCfgCurrent}
+                  abat10RetCfg={abat10RetCfgCurrent}
                   onUpdateSituation={updateSituation}
                   onAddChild={addChild}
                   onUpdateChildMode={updateChildMode}
@@ -357,6 +352,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   mutualisationConjoints={state.mutualisationConjoints}
                   declarant1={state.projectionNDeclarant1}
                   declarant2={state.projectionNDeclarant2}
+                  plafondMadelin={result?.plafondMadelin}
                   incomeFilters={incomeFilters}
                   abat10SalCfg={abat10SalCfgCurrent}
                   abat10RetCfg={abat10RetCfgCurrent}
@@ -381,6 +377,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   mutualisationConjoints={state.mutualisationConjoints}
                   declarant1={state.projectionNDeclarant1}
                   declarant2={state.projectionNDeclarant2}
+                  plafondMadelin={result?.plafondMadelin}
                   incomeFilters={incomeFilters}
                   abat10SalCfg={abat10SalCfgCurrent}
                   abat10RetCfg={abat10RetCfgCurrent}
@@ -407,107 +404,16 @@ export default function PerPotentielSimulator(): React.ReactElement {
 
         {state.mode !== null && (
         <aside className="per-potentiel-context sim-grid__col sim-grid__col--sticky">
-          <div className="premium-card per-potentiel-context-card sim-summary-card">
-            <div className="sim-card__title-row">
-              <div className="sim-card__icon">
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-                  <polyline points="14 2 14 8 20 8" />
-                </svg>
-              </div>
-              <h3 className="sim-card__title">Potentiel</h3>
-            </div>
-            <div className="sim-divider" />
-            <div className="per-potentiel-context-list">
-              {parcoursPills.length > 0 && (
-                <div className="per-potentiel-context-item">
-                  <span className="per-potentiel-context-label per-potentiel-context-label--small">Parcours</span>
-                  <div className="per-potentiel-pills">
-                    {parcoursPills.map((pill) => (
-                      <span
-                        key={pill.label}
-                        className={`per-potentiel-pill${pill.on ? ' is-on' : ''}`}
-                      >
-                        {pill.label}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              )}
-              {(state.step === 2 || state.step === 3) && (
-                <div className="per-avis-sidebar-kpis per-potentiel-context-item">
-                  <span className="per-potentiel-context-label per-potentiel-context-label--small">
-                    Potentiel 163 quatervicies
-                  </span>
-                  <div className="per-potentiel-mini-kpis">
-                    <div className="per-potentiel-mini-kpi">
-                      <span className="per-potentiel-mini-kpi-label">Déclarant 1</span>
-                      <strong className="per-potentiel-mini-kpi-value">
-                        {fmtCurrency(totalAvisIrD1)}
-                      </strong>
-                    </div>
-                    <div className="per-potentiel-mini-kpi">
-                      <span className="per-potentiel-mini-kpi-label">Déclarant 2</span>
-                      <strong className="per-potentiel-mini-kpi-value">
-                        {fmtCurrency(totalAvisIrD2)}
-                      </strong>
-                    </div>
-                  </div>
-                </div>
-              )}
-            </div>
-          </div>
-
-          {result && state.step !== 5 && (
-            <div className="premium-card per-potentiel-context-card sim-summary-card sim-summary-card--secondary">
-              <div className="sim-card__title-row">
-                <div className="sim-card__icon">
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                    <line x1="12" y1="20" x2="12" y2="10" />
-                    <line x1="18" y1="20" x2="18" y2="4" />
-                    <line x1="6" y1="20" x2="6" y2="16" />
-                  </svg>
-                </div>
-                <h3 className="sim-card__title">Aperçu en direct</h3>
-              </div>
-              <div className="sim-divider sim-divider--tight" />
-              <div className="per-potentiel-mini-kpis">
-                <div className="per-potentiel-mini-kpis-row">
-                  <div className="per-potentiel-mini-kpi">
-                    <span className="per-potentiel-mini-kpi-label">TMI</span>
-                    <strong className="per-potentiel-mini-kpi-value">
-                      {fmtPercent(result.situationFiscale.tmi)}
-                    </strong>
-                  </div>
-                  <div className="per-potentiel-mini-kpi">
-                    <span className="per-potentiel-mini-kpi-label">Nombre de parts</span>
-                    <strong className="per-potentiel-mini-kpi-value">
-                      {state.nombreParts.toLocaleString('fr-FR')}
-                    </strong>
-                  </div>
-                </div>
-                <div className="per-potentiel-mini-kpi">
-                  <span className="per-potentiel-mini-kpi-label">IR estimé</span>
-                  <strong className="per-potentiel-mini-kpi-value">
-                    {fmtCurrency(result.situationFiscale.irEstime)}
-                  </strong>
-                </div>
-                <div className="per-potentiel-mini-kpi">
-                  <span className="per-potentiel-mini-kpi-label">Disponible D1</span>
-                  <strong className="per-potentiel-mini-kpi-value">
-                    {fmtCurrency(result.plafond163Q.declarant1.disponibleRestant)}
-                  </strong>
-                </div>
-                {isCouple && result.plafond163Q.declarant2 && (
-                  <div className="per-potentiel-mini-kpi">
-                    <span className="per-potentiel-mini-kpi-label">Disponible D2</span>
-                    <strong className="per-potentiel-mini-kpi-value">
-                      {fmtCurrency(result.plafond163Q.declarant2.disponibleRestant)}
-                    </strong>
-                  </div>
-                )}
-              </div>
-            </div>
+          {state.step !== 5 && (
+            <PerPotentielContextSidebar
+              step={state.step}
+              isCouple={isCouple}
+              showRevenusPreview={isRevenusStep}
+              parcoursPills={parcoursPills}
+              totalAvisIrD1={totalAvisIrD1}
+              totalAvisIrD2={totalAvisIrD2}
+              result={result}
+            />
           )}
 
           {result && state.step === 5 && (

--- a/src/features/per/components/potentiel/PerSynthesisSidebar.tsx
+++ b/src/features/per/components/potentiel/PerSynthesisSidebar.tsx
@@ -25,10 +25,10 @@ export function PerSynthesisSidebar({
   versementEnvisage,
   onSetVersement,
 }: PerSynthesisSidebarProps): React.ReactElement {
-  const totalDispo = result.plafond163Q.declarant1.disponibleRestant
-    + (result.plafond163Q.declarant2?.disponibleRestant ?? 0);
-  const totalPlafond = result.plafond163Q.declarant1.totalDisponible
-    + (result.plafond163Q.declarant2?.totalDisponible ?? 0);
+  const totalDispo = result.deductionFlow163Q.declarant1.disponibleRestant
+    + (result.deductionFlow163Q.declarant2?.disponibleRestant ?? 0);
+  const totalPlafond = result.deductionFlow163Q.declarant1.plafondDisponible
+    + (result.deductionFlow163Q.declarant2?.plafondDisponible ?? 0);
   const used = totalPlafond - totalDispo;
   const donutTotal = used + totalDispo;
   const donutR = 27;

--- a/src/features/per/components/potentiel/steps/AvisIrStep.test.tsx
+++ b/src/features/per/components/potentiel/steps/AvisIrStep.test.tsx
@@ -48,7 +48,7 @@ describe('AvisIrStep', () => {
     expect(html).toContain('Rubrique');
     expect(html).toContain('Déclarant 1');
     expect(html).toContain('Déclarant 2');
-    expect(html).toContain('Potentiel 163 quatervicies pour les cotisations versées en 2025');
+    expect(html).toContain('Plafond pour les cotisations versées en 2025');
     expect(html).toContain(fmtCurrency(11000));
     expect(html).toContain(fmtCurrency(7000));
     expect(html).toContain('aria-label="Plafond non utilisé pour les revenus de 2022 - Déclarant 1"');

--- a/src/features/per/components/potentiel/steps/AvisIrStep.tsx
+++ b/src/features/per/components/potentiel/steps/AvisIrStep.tsx
@@ -77,7 +77,6 @@ export default function AvisIrStep({
   return (
     <div className="per-step per-step--avis">
       <div className="per-avis-intro">
-        <p className="premium-section-title">Avis d&apos;impôt</p>
         <p className="per-avis-copy">
           Renseignez les montants relevés sur l&apos;avis IR {avisContext.taxYear}. Le potentiel
           163 quatervicies correspond à l&apos;addition des trois reports non utilisés et du plafond
@@ -124,7 +123,7 @@ export default function AvisIrStep({
 
         <div className="per-avis-matrix-row per-avis-matrix-row--total" role="row">
           <div className="per-avis-matrix-label per-avis-matrix-label--total" role="rowheader">
-            Potentiel 163 quatervicies pour les cotisations versées en {avisContext.taxYear}
+            Plafond pour les cotisations versées en {avisContext.taxYear}
           </div>
           <div className="per-avis-matrix-operator per-avis-matrix-operator--total" aria-hidden="true">
             =

--- a/src/features/per/components/potentiel/steps/PerIncomeTable.tsx
+++ b/src/features/per/components/potentiel/steps/PerIncomeTable.tsx
@@ -7,7 +7,6 @@ import { formatInteger } from '../../../../../utils/formatNumber';
 import { PerAmountInput } from '../PerAmountInput';
 
 export type PerIncomeFilters = {
-  tns: boolean;
   pension: boolean;
   foncier: boolean;
 };
@@ -118,10 +117,12 @@ function PerTableAmountInput({
   value,
   ariaLabel,
   onChange,
+  disabled = false,
 }: {
   value: number;
   ariaLabel: string;
   onChange: (_value: number) => void;
+  disabled?: boolean;
 }): React.ReactElement {
   return (
     <SimFieldShell className="per-table-input" rowClassName="per-table-input__row">
@@ -129,11 +130,27 @@ function PerTableAmountInput({
         value={value}
         ariaLabel={ariaLabel}
         className="per-table-input__control"
+        disabled={disabled}
         onChange={onChange}
       />
       <span className="per-table-input__unit sim-field__unit" aria-hidden="true">€</span>
     </SimFieldShell>
   );
+}
+
+function buildTnsTogglePatch(enabled: boolean): Partial<DeclarantRevenus> {
+  if (enabled) {
+    return { statutTns: true };
+  }
+
+  return {
+    statutTns: false,
+    art62: 0,
+    bic: 0,
+    cotisationsMadelin154bis: 0,
+    cotisationsMadelinRetraite: 0,
+    cotisationsPrevo: 0,
+  };
 }
 
 function DividerRow({ isCouple }: { isCouple: boolean }): React.ReactElement {
@@ -165,7 +182,7 @@ export function PerIncomeTable({
   onToggleIncomeFilter: (_key: keyof PerIncomeFilters) => void;
   onUpdateDeclarant: (_decl: 1 | 2, _patch: Partial<DeclarantRevenus>) => void;
 }): React.ReactElement {
-  const showTnsRows = incomeFilters.tns === true;
+  const showTnsRows = declarant1.statutTns || declarant2.statutTns;
   const showPensionRows = incomeFilters.pension === true;
   const showFoncierRow = incomeFilters.foncier === true;
 
@@ -192,13 +209,24 @@ export function PerIncomeTable({
           <div className="per-income-filters" role="group" aria-label="Filtres des lignes de revenus imposables">
             <button
               type="button"
-              className={`per-income-filter-btn${showTnsRows ? ' is-active' : ''}`}
-              onClick={() => onToggleIncomeFilter('tns')}
-              aria-pressed={showTnsRows}
-              data-testid="per-filter-tns"
+              className={`per-income-filter-btn${declarant1.statutTns ? ' is-active' : ''}`}
+              onClick={() => onUpdateDeclarant(1, buildTnsTogglePatch(!declarant1.statutTns))}
+              aria-pressed={declarant1.statutTns}
+              data-testid="per-toggle-tns-d1"
             >
-              TNS
+              D1 TNS
             </button>
+            {isCouple && (
+              <button
+                type="button"
+                className={`per-income-filter-btn${declarant2.statutTns ? ' is-active' : ''}`}
+                onClick={() => onUpdateDeclarant(2, buildTnsTogglePatch(!declarant2.statutTns))}
+                aria-pressed={declarant2.statutTns}
+                data-testid="per-toggle-tns-d2"
+              >
+                D2 TNS
+              </button>
+            )}
             <button
               type="button"
               className={`per-income-filter-btn${showPensionRows ? ' is-active' : ''}`}
@@ -261,6 +289,7 @@ export function PerIncomeTable({
                   <PerTableAmountInput
                     value={declarant1.art62}
                     ariaLabel="Revenus des associés ou gérants déclarant 1"
+                    disabled={!declarant1.statutTns}
                     onChange={(value) => onUpdateDeclarant(1, { art62: value })}
                   />
                 </td>
@@ -268,6 +297,7 @@ export function PerIncomeTable({
                   <PerTableAmountInput
                     value={declarant2.art62}
                     ariaLabel="Revenus des associés ou gérants déclarant 2"
+                    disabled={!declarant2.statutTns}
                     onChange={(value) => onUpdateDeclarant(2, { art62: value })}
                   />
                 </td>
@@ -334,6 +364,7 @@ export function PerIncomeTable({
                   <PerTableAmountInput
                     value={declarant1.bic}
                     ariaLabel="BIC BNC BA imposables déclarant 1"
+                    disabled={!declarant1.statutTns}
                     onChange={(value) => onUpdateDeclarant(1, { bic: value })}
                   />
                 </td>
@@ -341,6 +372,7 @@ export function PerIncomeTable({
                   <PerTableAmountInput
                     value={declarant2.bic}
                     ariaLabel="BIC BNC BA imposables déclarant 2"
+                    disabled={!declarant2.statutTns}
                     onChange={(value) => onUpdateDeclarant(2, { bic: value })}
                   />
                 </td>

--- a/src/features/per/components/potentiel/steps/SituationFiscaleStep.test.tsx
+++ b/src/features/per/components/potentiel/steps/SituationFiscaleStep.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import SituationFiscaleStep from './SituationFiscaleStep';
 
 const baseDeclarant = {
+  statutTns: false,
   salaires: 45000,
   fraisReels: false,
   fraisReelsMontant: 0,
@@ -30,7 +31,8 @@ const baseProps = {
   mutualisationConjoints: false,
   declarant1: baseDeclarant,
   declarant2: baseDeclarant,
-  incomeFilters: { tns: false, pension: false, foncier: false },
+  plafondMadelin: undefined,
+  incomeFilters: { pension: false, foncier: false },
   abat10SalCfg: { plafond: 14522, plancher: 495 },
   abat10RetCfg: { plafond: 4399, plancher: 450 },
   onUpdateSituation: vi.fn(),
@@ -50,12 +52,13 @@ describe('SituationFiscaleStep', () => {
       />,
     );
 
-    expect(html).not.toContain('Nombre de parts calculÃ©');
-    expect(html).not.toContain('AperÃ§u fiscal');
+    expect(html).not.toContain('Nombre de parts calcul');
+    expect(html).not.toContain('Aperçu fiscal');
     expect(html.indexOf('Situation familiale')).toBeLessThan(html.indexOf('Revenus imposables'));
     expect(html.indexOf('Revenus imposables')).toBeLessThan(html.indexOf('Versements retraite'));
     expect(html).toContain('Ajouter un enfant');
     expect(html).not.toContain('Mutualisation des plafonds (case 6QR)');
+    expect(html).toContain('per-checkbox-label--isole');
   });
 
   it('renders mutualisation des plafonds inside the versements block for couples', () => {
@@ -72,16 +75,17 @@ describe('SituationFiscaleStep', () => {
     expect(html.indexOf('Versements retraite')).toBeLessThan(html.indexOf('Mutualisation des plafonds (case 6QR)'));
   });
 
-  it('renders the conditional revenu rows from the IR-like filters', () => {
+  it('renders the conditional revenu rows from the toggles and filters', () => {
     const html = renderToStaticMarkup(
       <SituationFiscaleStep
         showFoyerCard={false}
         {...baseProps}
-        incomeFilters={{ tns: true, pension: true, foncier: true }}
+        declarant1={{ ...baseDeclarant, statutTns: true }}
+        incomeFilters={{ pension: true, foncier: true }}
       />,
     );
 
-    expect(html).toContain('TNS');
+    expect(html).toContain('D1 TNS');
     expect(html).toContain('Pension');
     expect(html).toContain('Foncier');
     expect(html).toContain('Revenus des associés / gérants');
@@ -91,17 +95,18 @@ describe('SituationFiscaleStep', () => {
     expect(html).toContain('Revenus fonciers nets');
   });
 
-  it('uses the updated contribution notes without adding unsupported 2042 boxes', () => {
+  it('uses the updated contribution notes and info button', () => {
     const html = renderToStaticMarkup(
       <SituationFiscaleStep
         showFoyerCard={false}
         {...baseProps}
-        incomeFilters={{ tns: true, pension: false, foncier: false }}
+        declarant1={{ ...baseDeclarant, statutTns: true }}
       />,
     );
 
     expect(html).toContain('2042 : 6OS / 6OT');
-    expect(html).toContain('contrat retraite, distinct du PER 154 bis');
-    expect(html).toContain('employeur, réduit le plafond 163Q');
+    expect(html).toContain('contribue à 6QS / 6QT');
+    expect(html).toContain('nécessaire pour le calcul de l');
+    expect(html).toContain('Afficher le détail des enveloppes Madelin 154 bis');
   });
 });

--- a/src/features/per/components/potentiel/steps/SituationFiscaleStep.tsx
+++ b/src/features/per/components/potentiel/steps/SituationFiscaleStep.tsx
@@ -2,11 +2,12 @@
  * SituationFiscaleStep - Generic fiscal input screen for N-1 reconstruction or N projection.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { SimSelect } from '@/components/ui/sim/SimSelect';
-import type { DeclarantRevenus } from '../../../../../engine/per';
+import type { DeclarantRevenus, PlafondMadelinDetail } from '../../../../../engine/per';
 import type { PerChildDraft } from '../../../utils/perParts';
 import { PerAmountInput } from '../PerAmountInput';
+import { PerMadelinInfoModal } from '../PerMadelinInfoModal';
 import {
   PerIncomeTable,
   SectionHeader,
@@ -27,6 +28,10 @@ interface SituationFiscaleStepProps {
   mutualisationConjoints: boolean;
   declarant1: DeclarantRevenus;
   declarant2: DeclarantRevenus;
+  plafondMadelin?: {
+    declarant1: PlafondMadelinDetail;
+    declarant2?: PlafondMadelinDetail;
+  };
   incomeFilters: PerIncomeFilters;
   abat10SalCfg: PerAbattementConfig;
   abat10RetCfg: PerAbattementConfig;
@@ -62,6 +67,7 @@ export default function SituationFiscaleStep({
   mutualisationConjoints,
   declarant1,
   declarant2,
+  plafondMadelin,
   incomeFilters,
   abat10SalCfg,
   abat10RetCfg,
@@ -72,19 +78,22 @@ export default function SituationFiscaleStep({
   onToggleIncomeFilter,
   onUpdateDeclarant,
 }: SituationFiscaleStepProps): React.ReactElement {
+  const [showMadelinInfo, setShowMadelinInfo] = useState(false);
+  const showTnsContributionRows = declarant1.statutTns || declarant2.statutTns;
   const contributionRows: {
     label: string;
     note: string;
     key: ContributionFieldKey;
     tnsOnly?: boolean;
+    infoAction?: boolean;
   }[] = [
     { label: 'PER 163 quatervicies', note: variant === 'revenus-n1' ? '2042 : 6NS / 6NT' : 'année en cours', key: 'cotisationsPer163Q' },
     { label: 'PERP et assimilés', note: variant === 'revenus-n1' ? '2042 : 6RS / 6RT' : 'année en cours', key: 'cotisationsPerp' },
     { label: 'Art. 83 employeur + salarié', note: variant === 'revenus-n1' ? '2042 : 6QS / 6QT' : 'année en cours', key: 'cotisationsArt83' },
-    { label: 'PER 154 bis', note: variant === 'revenus-n1' ? '2042 : 6OS / 6OT' : 'année en cours', key: 'cotisationsMadelin154bis', tnsOnly: true },
-    { label: 'Madelin retraite', note: 'contrat retraite, distinct du PER 154 bis', key: 'cotisationsMadelinRetraite', tnsOnly: true },
-    { label: 'Abondement PERCO', note: 'employeur, réduit le plafond 163Q', key: 'abondementPerco' },
-    { label: 'Prévoyance Madelin', note: 'part non retraite', key: 'cotisationsPrevo', tnsOnly: true },
+    { label: 'PER 154 bis', note: variant === 'revenus-n1' ? '2042 : 6OS / 6OT' : 'année en cours', key: 'cotisationsMadelin154bis', tnsOnly: true, infoAction: true },
+    { label: 'Madelin retraite', note: 'contribue à 6QS / 6QT', key: 'cotisationsMadelinRetraite', tnsOnly: true },
+    { label: 'Abondement PERCO', note: 'contribue à 6QS / 6QT', key: 'abondementPerco' },
+    { label: 'Prévoyance Madelin', note: 'nécessaire pour le calcul de l\'assiette de versement 154 bis', key: 'cotisationsPrevo', tnsOnly: true },
   ];
 
   return (
@@ -97,9 +106,9 @@ export default function SituationFiscaleStep({
           />
 
           <div className="per-situation-foyer-grid">
-            <div className="per-field premium-field" data-testid="per-situation-field">
-              <label>Situation familiale</label>
+            <div className="per-field premium-field per-field--no-label" data-testid="per-situation-field">
               <SimSelect
+                ariaLabel="Situation familiale"
                 value={situationFamiliale}
                 onChange={(value) => {
                   onUpdateSituation({
@@ -112,14 +121,14 @@ export default function SituationFiscaleStep({
                 ]}
               />
               {situationFamiliale === 'celibataire' && (
-                <label className="per-checkbox-label">
+                <label className="per-checkbox-label per-checkbox-label--small per-checkbox-label--isole">
                   <input
                     type="checkbox"
                     className="per-checkbox"
                     checked={isole}
                     onChange={(event) => onUpdateSituation({ isole: event.target.checked })}
                   />
-                  <span>Parent isolé</span>
+                  <span className="per-checkbox-label__text">Parent isolé</span>
                 </label>
               )}
             </div>
@@ -193,10 +202,22 @@ export default function SituationFiscaleStep({
           <div className="per-contribution-table-head">Déclarant 1</div>
           {isCouple && <div className="per-contribution-table-head">Déclarant 2</div>}
 
-          {contributionRows.filter(row => !row.tnsOnly || incomeFilters.tns).map((row) => (
+          {contributionRows.filter(row => !row.tnsOnly || showTnsContributionRows).map((row) => (
             <React.Fragment key={row.key}>
               <div className="per-contribution-table-label">
-                <span>{row.label}</span>
+                <span className="per-contribution-table-label__text">
+                  {row.label}
+                  {row.infoAction && (
+                    <button
+                      type="button"
+                      className="per-info-btn"
+                      onClick={() => setShowMadelinInfo(true)}
+                      aria-label="Afficher le détail des enveloppes Madelin 154 bis"
+                    >
+                      i
+                    </button>
+                  )}
+                </span>
                 <small>{row.note}</small>
               </div>
               <div className="per-contribution-table-cell">
@@ -205,6 +226,7 @@ export default function SituationFiscaleStep({
                   value={declarant1[row.key]}
                   ariaLabel={`${row.label} déclarant 1`}
                   className="per-contribution-input"
+                  disabled={Boolean(row.tnsOnly && !declarant1.statutTns)}
                   onChange={(value) => onUpdateDeclarant(1, { [row.key]: value })}
                 />
               </div>
@@ -215,6 +237,7 @@ export default function SituationFiscaleStep({
                     value={declarant2[row.key]}
                     ariaLabel={`${row.label} déclarant 2`}
                     className="per-contribution-input"
+                    disabled={Boolean(row.tnsOnly && !declarant2.statutTns)}
                     onChange={(value) => onUpdateDeclarant(2, { [row.key]: value })}
                   />
                 </div>
@@ -234,6 +257,15 @@ export default function SituationFiscaleStep({
           </label>
         )}
       </div>
+
+      {showMadelinInfo && (
+        <PerMadelinInfoModal
+          declarant1={plafondMadelin?.declarant1}
+          declarant2={plafondMadelin?.declarant2}
+          isCouple={isCouple}
+          onClose={() => setShowMadelinInfo(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/features/per/components/potentiel/steps/SynthesePotentielStep.tsx
+++ b/src/features/per/components/potentiel/steps/SynthesePotentielStep.tsx
@@ -3,7 +3,13 @@
  */
 
 import React from 'react';
-import type { PerPotentielResult, PlafondDetail, PlafondMadelinDetail } from '../../../../../engine/per';
+import type {
+  PerDeductionDetail,
+  PerPotentielResult,
+  PerProjectionAvisDetail,
+  PlafondDetail,
+  PlafondMadelinDetail,
+} from '../../../../../engine/per';
 
 interface SynthesePotentielStepProps {
   result: PerPotentielResult | null;
@@ -20,22 +26,26 @@ const fmtCurrency = (value: number): string =>
 function PlafondBreakdownCard({
   label,
   detail,
+  deduction,
 }: {
   label: string;
   detail: PlafondDetail;
+  deduction: PerDeductionDetail;
 }): React.ReactElement {
   const rows = [
-    { label: 'Plafond calculé année N', value: detail.plafondCalculeN },
+    { label: 'Plafond calculé sur l’avis', value: detail.plafondCalculeN },
     { label: 'Report N-3', value: detail.nonUtiliseN3 },
     { label: 'Report N-2', value: detail.nonUtiliseN2 },
     { label: 'Report N-1', value: detail.nonUtiliseN1 },
-    { label: 'Cotisations déjà versées', value: detail.cotisationsDejaVersees },
+    { label: 'Cotisations 163Q / PERP versées', value: deduction.cotisationsVersees },
+    { label: 'Cotisations retenues pour l’IR', value: deduction.cotisationsRetenuesIr },
+    { label: 'Plafond après mutualisation', value: deduction.plafondApresMutualisation },
   ];
 
   return (
     <div className="premium-card-compact per-summary-breakdown-card">
       <div className="per-summary-card-head">
-        <p className="premium-section-title">Plafond personnel</p>
+        <p className="premium-section-title">Potentiel 163 quatervicies</p>
         <h4 className="per-summary-card-title">{label}</h4>
       </div>
 
@@ -47,12 +57,12 @@ function PlafondBreakdownCard({
           </div>
         ))}
         <div className="per-summary-breakdown-row per-summary-breakdown-row--total">
-          <span>Total disponible</span>
+          <span>Total disponible issu de l’avis</span>
           <strong>{fmtCurrency(detail.totalDisponible)}</strong>
         </div>
-        <div className={`per-summary-breakdown-row per-summary-breakdown-row--highlight ${detail.depassement ? 'is-alert' : ''}`}>
+        <div className={`per-summary-breakdown-row per-summary-breakdown-row--highlight ${deduction.cotisationsNonDeductibles > 0 ? 'is-alert' : ''}`}>
           <span>Disponible restant</span>
-          <strong>{fmtCurrency(detail.disponibleRestant)}</strong>
+          <strong>{fmtCurrency(deduction.disponibleRestant)}</strong>
         </div>
       </div>
     </div>
@@ -75,24 +85,68 @@ function MadelinCard({
 
       <div className="per-summary-breakdown-list">
         <div className="per-summary-breakdown-row">
-          <span>Assiette Madelin</span>
-          <strong>{fmtCurrency(detail.assiette)}</strong>
+          <span>Assiette de versement</span>
+          <strong>{fmtCurrency(detail.assietteVersement)}</strong>
+        </div>
+        <div className="per-summary-breakdown-row">
+          <span>Assiette de report 2042</span>
+          <strong>{fmtCurrency(detail.assietteReport)}</strong>
         </div>
         <div className="per-summary-breakdown-row">
           <span>Enveloppe 15 %</span>
-          <strong>{fmtCurrency(detail.enveloppe15)}</strong>
+          <strong>{fmtCurrency(detail.enveloppe15Versement)}</strong>
         </div>
         <div className="per-summary-breakdown-row">
-          <span>Enveloppe 10 %</span>
+          <span>Enveloppe 10 % commune</span>
           <strong>{fmtCurrency(detail.enveloppe10)}</strong>
         </div>
         <div className="per-summary-breakdown-row per-summary-breakdown-row--total">
-          <span>Potentiel total</span>
-          <strong>{fmtCurrency(detail.potentielTotal)}</strong>
-        </div>
-        <div className={`per-summary-breakdown-row per-summary-breakdown-row--highlight ${detail.depassement ? 'is-alert' : ''}`}>
           <span>Disponible restant</span>
           <strong>{fmtCurrency(detail.disponibleRestant)}</strong>
+        </div>
+        <div className={`per-summary-breakdown-row per-summary-breakdown-row--highlight ${detail.depassement ? 'is-alert' : ''}`}>
+          <span>Réintégration fiscale</span>
+          <strong>{fmtCurrency(detail.surplusAReintegrer)}</strong>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProjectionCard({
+  label,
+  detail,
+}: {
+  label: string;
+  detail: PerProjectionAvisDetail;
+}): React.ReactElement {
+  return (
+    <div className="premium-card-compact per-summary-breakdown-card">
+      <div className="per-summary-card-head">
+        <p className="premium-section-title">Prochain avis IR</p>
+        <h4 className="per-summary-card-title">{label}</h4>
+      </div>
+
+      <div className="per-summary-breakdown-list">
+        <div className="per-summary-breakdown-row">
+          <span>Reliquat N-2</span>
+          <strong>{fmtCurrency(detail.nonUtiliseN2)}</strong>
+        </div>
+        <div className="per-summary-breakdown-row">
+          <span>Reliquat N-1</span>
+          <strong>{fmtCurrency(detail.nonUtiliseN1)}</strong>
+        </div>
+        <div className="per-summary-breakdown-row">
+          <span>Reliquat N</span>
+          <strong>{fmtCurrency(detail.nonUtiliseN)}</strong>
+        </div>
+        <div className="per-summary-breakdown-row">
+          <span>Plafond calculé</span>
+          <strong>{fmtCurrency(detail.plafondCalculeN)}</strong>
+        </div>
+        <div className="per-summary-breakdown-row per-summary-breakdown-row--total">
+          <span>Total projeté</span>
+          <strong>{fmtCurrency(detail.plafondTotal)}</strong>
         </div>
       </div>
     </div>
@@ -115,9 +169,10 @@ export default function SynthesePotentielStep({
 
   const {
     plafond163Q,
+    deductionFlow163Q,
     plafondMadelin,
-    estTNS,
     declaration2042,
+    projectionAvisSuivant,
     warnings,
   } = result;
 
@@ -137,7 +192,7 @@ export default function SynthesePotentielStep({
       d2Value: declaration2042.case6RT ?? 0,
     },
     {
-      label: 'Art. 83',
+      label: 'Flux agrégé Art. 83 / PERCO / Madelin retraite',
       d1Case: '6QS',
       d1Value: declaration2042.case6QS,
       d2Case: '6QT',
@@ -155,16 +210,24 @@ export default function SynthesePotentielStep({
   return (
     <div className="per-step per-step--summary">
       <div className={`per-summary-breakdown-grid ${isCouple && plafond163Q.declarant2 ? 'is-couple' : ''}`}>
-        <PlafondBreakdownCard label="Déclarant 1" detail={plafond163Q.declarant1} />
-        {isCouple && plafond163Q.declarant2 && (
-          <PlafondBreakdownCard label="Déclarant 2" detail={plafond163Q.declarant2} />
+        <PlafondBreakdownCard
+          label="Déclarant 1"
+          detail={plafond163Q.declarant1}
+          deduction={deductionFlow163Q.declarant1}
+        />
+        {isCouple && plafond163Q.declarant2 && deductionFlow163Q.declarant2 && (
+          <PlafondBreakdownCard
+            label="Déclarant 2"
+            detail={plafond163Q.declarant2}
+            deduction={deductionFlow163Q.declarant2}
+          />
         )}
       </div>
 
       <div className="premium-card per-summary-section-card">
         <div className="per-summary-card-head">
           <p className="premium-section-title">Restitution 2042</p>
-          <h4 className="per-summary-card-title">Cases à reporter</h4>
+          <h4 className="per-summary-card-title">Reports à opérer</h4>
         </div>
 
         <table className="premium-table per-summary-table">
@@ -203,23 +266,37 @@ export default function SynthesePotentielStep({
         </table>
       </div>
 
-      {estTNS && plafondMadelin && (
+      {plafondMadelin && (
         <div className="premium-card per-summary-section-card">
           <div className="per-summary-card-head">
             <p className="premium-section-title">Madelin</p>
-            <h4 className="per-summary-card-title">Potentiel 154 bis pour travailleurs non salariés</h4>
+            <h4 className="per-summary-card-title">Enveloppes 154 bis</h4>
           </div>
 
           <div className={`per-summary-breakdown-grid ${isCouple ? 'is-couple' : ''}`}>
-            {plafondMadelin.declarant1 && (
+            {plafondMadelin.declarant1.assietteVersement > 0 && (
               <MadelinCard label="Déclarant 1" detail={plafondMadelin.declarant1} />
             )}
-            {isCouple && plafondMadelin.declarant2 && (
+            {isCouple && plafondMadelin.declarant2 && plafondMadelin.declarant2.assietteVersement > 0 && (
               <MadelinCard label="Déclarant 2" detail={plafondMadelin.declarant2} />
             )}
           </div>
         </div>
       )}
+
+      <div className="premium-card per-summary-section-card">
+        <div className="per-summary-card-head">
+          <p className="premium-section-title">Prochain avis IR</p>
+          <h4 className="per-summary-card-title">Reliquats projetés</h4>
+        </div>
+
+        <div className={`per-summary-breakdown-grid ${isCouple ? 'is-couple' : ''}`}>
+          <ProjectionCard label="Déclarant 1" detail={projectionAvisSuivant.declarant1} />
+          {isCouple && projectionAvisSuivant.declarant2 && (
+            <ProjectionCard label="Déclarant 2" detail={projectionAvisSuivant.declarant2} />
+          )}
+        </div>
+      </div>
 
       {warnings.length > 0 && (
         <div className="per-warnings per-warnings--stack">

--- a/src/features/per/export/perPotentielExcelExport.ts
+++ b/src/features/per/export/perPotentielExcelExport.ts
@@ -60,11 +60,16 @@ function pushMadelinRows(
   plafond: NonNullable<PerPotentielResult['plafondMadelin']>['declarant1'],
 ): void {
   rows.push([sec(label), sec('')]);
-  rows.push([txt('Assiette Madelin'), money(plafond.assiette)]);
-  rows.push([txt('Enveloppe 15%'), money(plafond.enveloppe15)]);
+  rows.push([txt('Assiette de versement'), money(plafond.assietteVersement)]);
+  rows.push([txt('Assiette de report 2042'), money(plafond.assietteReport)]);
+  rows.push([txt('Enveloppe 15% versement'), money(plafond.enveloppe15Versement)]);
+  rows.push([txt('Enveloppe 15% report'), money(plafond.enveloppe15Report)]);
   rows.push([txt('Enveloppe 10%'), money(plafond.enveloppe10)]);
-  rows.push([txt('Potentiel total'), money(plafond.potentielTotal)]);
   rows.push([txt('Cotisations versees'), money(plafond.cotisationsVersees)]);
+  rows.push([txt('Reste enveloppe 15% versement'), money(plafond.reste15Versement)]);
+  rows.push([txt('Reste enveloppe 15% report'), money(plafond.reste15Report)]);
+  rows.push([txt('Reste enveloppe 10%'), money(plafond.reste10)]);
+  rows.push([txt('Reintegration fiscale'), money(plafond.surplusAReintegrer)]);
   rows.push([txt('Disponible restant'), money(plafond.disponibleRestant)]);
   rows.push([txt('Depassement'), txt(yesNo(plafond.depassement))]);
 }
@@ -99,8 +104,12 @@ function buildSyntheseSheet(
   rows.push([txt('Marge dans la TMI'), money(result.situationFiscale.montantDansLaTMI)]);
 
   pushPlafondRows(rows, 'Plafond 163 quatervicies - Declarant 1', result.plafond163Q.declarant1);
+  rows.push([txt('Cotisations retenues IR - Declarant 1'), money(result.deductionFlow163Q.declarant1.cotisationsRetenuesIr)]);
+  rows.push([txt('Disponible restant après mutualisation - Declarant 1'), money(result.deductionFlow163Q.declarant1.disponibleRestant)]);
   if (result.plafond163Q.declarant2) {
     pushPlafondRows(rows, 'Plafond 163 quatervicies - Declarant 2', result.plafond163Q.declarant2);
+    rows.push([txt('Cotisations retenues IR - Declarant 2'), money(result.deductionFlow163Q.declarant2?.cotisationsRetenuesIr ?? 0)]);
+    rows.push([txt('Disponible restant après mutualisation - Declarant 2'), money(result.deductionFlow163Q.declarant2?.disponibleRestant ?? 0)]);
   }
 
   if (result.plafondMadelin?.declarant1) {
@@ -123,6 +132,20 @@ function buildSyntheseSheet(
     rows.push([txt('Simulation disponible'), txt('Non')]);
   }
 
+  rows.push([sec('Projection prochain avis IR'), sec('')]);
+  rows.push([txt('Declarant 1 - reliquat N-2'), money(result.projectionAvisSuivant.declarant1.nonUtiliseN2)]);
+  rows.push([txt('Declarant 1 - reliquat N-1'), money(result.projectionAvisSuivant.declarant1.nonUtiliseN1)]);
+  rows.push([txt('Declarant 1 - reliquat N'), money(result.projectionAvisSuivant.declarant1.nonUtiliseN)]);
+  rows.push([txt('Declarant 1 - plafond calcule'), money(result.projectionAvisSuivant.declarant1.plafondCalculeN)]);
+  rows.push([txt('Declarant 1 - total'), money(result.projectionAvisSuivant.declarant1.plafondTotal)]);
+  if (result.projectionAvisSuivant.declarant2) {
+    rows.push([txt('Declarant 2 - reliquat N-2'), money(result.projectionAvisSuivant.declarant2.nonUtiliseN2)]);
+    rows.push([txt('Declarant 2 - reliquat N-1'), money(result.projectionAvisSuivant.declarant2.nonUtiliseN1)]);
+    rows.push([txt('Declarant 2 - reliquat N'), money(result.projectionAvisSuivant.declarant2.nonUtiliseN)]);
+    rows.push([txt('Declarant 2 - plafond calcule'), money(result.projectionAvisSuivant.declarant2.plafondCalculeN)]);
+    rows.push([txt('Declarant 2 - total'), money(result.projectionAvisSuivant.declarant2.plafondTotal)]);
+  }
+
   if (result.warnings.length > 0) {
     rows.push([sec('Alertes'), sec('')]);
     result.warnings.forEach((warning, index) => {
@@ -142,7 +165,7 @@ function buildDeclarationSheet(result: PerPotentielResult): XlsxSheet {
     [h('Case'), h('Libelle'), h('Valeur')],
     [ctr('6NS'), txt('PER 163 quatervicies - Declarant 1'), money(result.declaration2042.case6NS)],
     [ctr('6RS'), txt('PERP et assimiles - Declarant 1'), money(result.declaration2042.case6RS)],
-    [ctr('6QS'), txt('Art. 83 - Declarant 1'), money(result.declaration2042.case6QS)],
+    [ctr('6QS'), txt('Art. 83 / PERCO / Madelin retraite - Declarant 1'), money(result.declaration2042.case6QS)],
     [ctr('6OS'), txt('PER 154 bis - Declarant 1'), money(result.declaration2042.case6OS)],
   ];
 
@@ -153,7 +176,7 @@ function buildDeclarationSheet(result: PerPotentielResult): XlsxSheet {
     rows.push([ctr('6RT'), txt('PERP et assimiles - Declarant 2'), money(result.declaration2042.case6RT)]);
   }
   if (typeof result.declaration2042.case6QT === 'number') {
-    rows.push([ctr('6QT'), txt('Art. 83 - Declarant 2'), money(result.declaration2042.case6QT)]);
+    rows.push([ctr('6QT'), txt('Art. 83 / PERCO / Madelin retraite - Declarant 2'), money(result.declaration2042.case6QT)]);
   }
   if (typeof result.declaration2042.case6OT === 'number') {
     rows.push([ctr('6OT'), txt('PER 154 bis - Declarant 2'), money(result.declaration2042.case6OT)]);

--- a/src/features/per/hooks/usePerPotentiel.ts
+++ b/src/features/per/hooks/usePerPotentiel.ts
@@ -17,8 +17,10 @@ import type {
 import type { FiscalContext } from '../../../hooks/useFiscalContext';
 import { getAvisReferenceYears, getPerWorkflowYears } from '../utils/perWorkflowYears';
 import { derivePerNombreParts, type PerChildDraft } from '../utils/perParts';
+import { shouldUseProjectionForCalculation } from '../utils/perProjectionScope';
+import { resolvePerCalculationYear } from '../utils/perCalculationYear';
 
-const SESSION_KEY = 'ser1:sim:per:potentiel:v3';
+const SESSION_KEY = 'ser1:sim:per:potentiel:v4';
 
 export type PerMode = 'versement-n' | 'declaration-n1';
 export type WizardStep = 1 | 2 | 3 | 4 | 5;
@@ -44,6 +46,7 @@ export interface PerPotentielState {
 }
 
 const EMPTY_DECLARANT: DeclarantRevenus = {
+  statutTns: false,
   salaires: 0,
   fraisReels: false,
   fraisReelsMontant: 0,
@@ -366,7 +369,13 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
     return {
       mode: state.mode,
       historicalBasis,
-      anneeRef: years.currentTaxYear,
+      ...resolvePerCalculationYear({
+        step: state.step,
+        mode: state.mode,
+        historicalBasis,
+        useProjection,
+        years,
+      }),
       situationFiscale: buildSituationInput(state, 'revenus-n1', isCouple),
       projectionFiscale: useProjection
         ? buildSituationInput(state, 'projection-n', isCouple)
@@ -379,15 +388,19 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
       taxSettings: fiscalContext._raw_tax,
       psSettings: fiscalContext._raw_ps,
     };
-  }, [state, years.currentTaxYear, isCouple, fiscalContext]);
+  }, [state, years, isCouple, fiscalContext]);
 
   const result = useMemo((): PerPotentielResult | null => {
     if (state.step < 3) {
       return null;
     }
 
-    const shouldUseProjection = state.mode === 'versement-n'
-      && (state.historicalBasis === 'current-avis' || state.needsCurrentYearEstimate);
+    const shouldUseProjection = shouldUseProjectionForCalculation({
+      step: state.step,
+      mode: state.mode,
+      historicalBasis: state.historicalBasis,
+      needsCurrentYearEstimate: state.needsCurrentYearEstimate,
+    });
     const input = buildInput(shouldUseProjection);
     if (!input) {
       return null;

--- a/src/features/per/styles/responsive.css
+++ b/src/features/per/styles/responsive.css
@@ -29,7 +29,8 @@
   .per-situation-foyer-grid,
   .per-summary-hero-grid,
   .per-summary-stat-grid,
-  .per-summary-simulation-grid {
+  .per-summary-simulation-grid,
+  .per-potentiel-preview-columns.is-couple {
     grid-template-columns: 1fr;
   }
 
@@ -46,6 +47,13 @@
   .per-section-header-actions,
   .per-income-filters {
     justify-content: flex-start;
+  }
+
+  .per-potentiel-preview-columns.is-couple .per-potentiel-preview-column + .per-potentiel-preview-column {
+    padding-left: 0;
+    padding-top: 12px;
+    border-left: none;
+    border-top: 1px solid var(--color-c8);
   }
 
   .per-avis-matrix-head-row,

--- a/src/features/per/styles/steps.css
+++ b/src/features/per/styles/steps.css
@@ -383,6 +383,10 @@
   gap: 0.45rem;
 }
 
+.per-field--no-label {
+  gap: 0.25rem;
+}
+
 .per-field label,
 .per-field > span {
   font-size: 0.85rem;
@@ -654,16 +658,35 @@
 .per-checkbox {
   accent-color: var(--color-c2);
   cursor: pointer;
+  margin: 0;
+  flex-shrink: 0;
 }
 
 .per-checkbox-label {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 6px;
   margin-top: 6px;
   font-size: 12px;
   color: var(--color-c9);
   cursor: pointer;
+  line-height: 1.3;
+}
+
+.per-checkbox-label--small {
+  margin-top: 4px;
+  font-size: 10px;
+  line-height: 1.2;
+}
+
+.per-checkbox-label--isole {
+  align-self: flex-start;
+  gap: 8px;
+  white-space: nowrap;
+}
+
+.per-checkbox-label__text {
+  display: inline-block;
 }
 
 .per-contribution-table {
@@ -705,9 +728,31 @@
   color: var(--color-c10);
 }
 
+.per-contribution-table-label__text {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .per-contribution-table-label small {
   font-size: 11px;
   color: var(--color-c9);
+}
+
+.per-info-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--color-c8);
+  border-radius: 999px;
+  background: var(--color-c7);
+  color: var(--color-c2);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
 }
 
 .per-contribution-table-cell {

--- a/src/features/per/styles/summary.css
+++ b/src/features/per/styles/summary.css
@@ -168,6 +168,19 @@
   border-left: 3px solid var(--color-c6);
 }
 
+.per-madelin-modal {
+  width: min(960px, calc(100vw - 32px));
+}
+
+.per-madelin-modal__body {
+  display: grid;
+  gap: 16px;
+}
+
+.per-madelin-modal-card {
+  height: 100%;
+}
+
 .per-summary-breakdown-list {
   display: grid;
   gap: 10px;

--- a/src/features/per/styles/wizard.css
+++ b/src/features/per/styles/wizard.css
@@ -203,6 +203,11 @@
   gap: 3px;
 }
 
+.per-potentiel-context-item--avis {
+  gap: 8px;
+  padding-bottom: 8px;
+}
+
 .per-potentiel-context-label {
   font-size: 11px;
   font-weight: 600;
@@ -220,6 +225,15 @@
 .per-potentiel-mini-kpis {
   display: grid;
   gap: 12px;
+}
+
+.per-potentiel-mini-kpis--avis {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.per-potentiel-mini-kpis--avis .per-potentiel-mini-kpi {
+  padding-bottom: 0;
+  border-bottom: none;
 }
 
 .per-potentiel-mini-kpis-row {
@@ -253,6 +267,56 @@
   font-size: 18px;
   font-weight: 700;
   color: var(--color-c1);
+}
+
+.per-potentiel-preview-section .per-potentiel-mini-kpi-value {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.per-potentiel-context-section {
+  display: grid;
+  gap: 12px;
+}
+
+.per-potentiel-preview-section {
+  display: grid;
+  gap: 12px;
+}
+
+.per-potentiel-preview-columns {
+  display: grid;
+  gap: 16px;
+}
+
+.per-potentiel-preview-columns.is-couple {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.per-potentiel-preview-column {
+  display: grid;
+  gap: 10px;
+}
+
+.per-potentiel-preview-columns.is-couple .per-potentiel-preview-column + .per-potentiel-preview-column {
+  padding-left: 16px;
+  border-left: 1px solid var(--color-c8);
+}
+
+.per-potentiel-preview-column__title {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: var(--color-c1);
+}
+
+.per-potentiel-context-section__title {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: var(--color-c9);
 }
 
 .per-step {

--- a/src/features/per/utils/perCalculationYear.test.ts
+++ b/src/features/per/utils/perCalculationYear.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { resolvePerCalculationYear } from './perCalculationYear';
+import type { PerWorkflowYears } from './perWorkflowYears';
+
+const years: PerWorkflowYears = {
+  currentTaxLabel: '2026 (revenus 2025)',
+  previousTaxLabel: '2025 (revenus 2024)',
+  currentTaxYear: 2026,
+  currentIncomeYear: 2025,
+  previousTaxYear: 2025,
+  previousIncomeYear: 2024,
+};
+
+describe('resolvePerCalculationYear', () => {
+  it('utilise le barème IR 2025 pour la tab Revenus 2025', () => {
+    expect(resolvePerCalculationYear({
+      step: 3,
+      mode: 'versement-n',
+      historicalBasis: 'previous-avis-plus-n1',
+      useProjection: false,
+      years,
+    })).toEqual({
+      anneeRef: 2025,
+      yearKey: 'previous',
+    });
+  });
+
+  it('utilise le barème courant pour la projection 2026', () => {
+    expect(resolvePerCalculationYear({
+      step: 4,
+      mode: 'versement-n',
+      historicalBasis: 'previous-avis-plus-n1',
+      useProjection: true,
+      years,
+    })).toEqual({
+      anneeRef: 2026,
+      yearKey: 'current',
+    });
+  });
+});

--- a/src/features/per/utils/perCalculationYear.ts
+++ b/src/features/per/utils/perCalculationYear.ts
@@ -1,0 +1,42 @@
+import type { PerHistoricalBasis, PerYearKey } from '../../../engine/per';
+import type { PerWorkflowYears } from './perWorkflowYears';
+
+type PerCalculationMode = 'versement-n' | 'declaration-n1' | null;
+type PerCalculationStep = 1 | 2 | 3 | 4 | 5;
+
+interface PerCalculationYearParams {
+  step: PerCalculationStep;
+  mode: PerCalculationMode;
+  historicalBasis: PerHistoricalBasis | null;
+  useProjection: boolean;
+  years: PerWorkflowYears;
+}
+
+export interface PerCalculationYear {
+  anneeRef: number;
+  yearKey: PerYearKey;
+}
+
+function resolveYearKey(anneeRef: number, years: PerWorkflowYears): PerYearKey {
+  if (anneeRef === years.previousTaxYear) {
+    return 'previous';
+  }
+
+  return 'current';
+}
+
+export function resolvePerCalculationYear({
+  mode,
+  historicalBasis,
+  useProjection,
+  years,
+}: PerCalculationYearParams): PerCalculationYear {
+  const anneeRef = useProjection || (mode === 'versement-n' && historicalBasis === 'current-avis')
+    ? years.currentTaxYear
+    : years.currentIncomeYear;
+
+  return {
+    anneeRef,
+    yearKey: resolveYearKey(anneeRef, years),
+  };
+}

--- a/src/features/per/utils/perProjectionScope.test.ts
+++ b/src/features/per/utils/perProjectionScope.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { shouldUseProjectionForCalculation } from './perProjectionScope';
+
+describe('shouldUseProjectionForCalculation', () => {
+  it('reste sur les revenus N-1 en step 3 pour le parcours avis N-1 + reconstitution N', () => {
+    expect(shouldUseProjectionForCalculation({
+      step: 3,
+      mode: 'versement-n',
+      historicalBasis: 'previous-avis-plus-n1',
+      needsCurrentYearEstimate: true,
+    })).toBe(false);
+  });
+
+  it('bascule sur la projection à partir de la step 4 quand l’estimation N est activée', () => {
+    expect(shouldUseProjectionForCalculation({
+      step: 4,
+      mode: 'versement-n',
+      historicalBasis: 'previous-avis-plus-n1',
+      needsCurrentYearEstimate: true,
+    })).toBe(true);
+  });
+
+  it('utilise la projection dès la step 3 pour le parcours avis IR courant', () => {
+    expect(shouldUseProjectionForCalculation({
+      step: 3,
+      mode: 'versement-n',
+      historicalBasis: 'current-avis',
+      needsCurrentYearEstimate: false,
+    })).toBe(true);
+  });
+
+  it('n’utilise jamais la projection pour le parcours déclaration N-1', () => {
+    expect(shouldUseProjectionForCalculation({
+      step: 5,
+      mode: 'declaration-n1',
+      historicalBasis: 'previous-avis-plus-n1',
+      needsCurrentYearEstimate: false,
+    })).toBe(false);
+  });
+});

--- a/src/features/per/utils/perProjectionScope.ts
+++ b/src/features/per/utils/perProjectionScope.ts
@@ -1,0 +1,28 @@
+import type { PerHistoricalBasis } from '../../../engine/per';
+
+export type PerProjectionScopeMode = 'versement-n' | 'declaration-n1' | null;
+export type PerProjectionScopeStep = 1 | 2 | 3 | 4 | 5;
+
+interface PerProjectionScopeParams {
+  step: PerProjectionScopeStep;
+  mode: PerProjectionScopeMode;
+  historicalBasis: PerHistoricalBasis | null;
+  needsCurrentYearEstimate: boolean;
+}
+
+export function shouldUseProjectionForCalculation({
+  step,
+  mode,
+  historicalBasis,
+  needsCurrentYearEstimate,
+}: PerProjectionScopeParams): boolean {
+  if (mode !== 'versement-n' || historicalBasis === null) {
+    return false;
+  }
+
+  if (historicalBasis === 'current-avis') {
+    return step >= 3;
+  }
+
+  return needsCurrentYearEstimate && step >= 4;
+}

--- a/src/pptx/presets/perDeckBuilder.ts
+++ b/src/pptx/presets/perDeckBuilder.ts
@@ -115,12 +115,14 @@ function buildSituationBody(data: PerDeckData): string {
 function buildPlafond163QBody(data: PerDeckData): string {
   const d1 = data.result.plafond163Q.declarant1;
   const d2 = data.result.plafond163Q.declarant2;
+  const flow1 = data.result.deductionFlow163Q.declarant1;
+  const flow2 = data.result.deductionFlow163Q.declarant2;
   const lines = [
-    `- Declarant 1 : plafond calcule ${euro(d1.plafondCalculeN)}, reports ${euro(d1.nonUtiliseN3)} / ${euro(d1.nonUtiliseN2)} / ${euro(d1.nonUtiliseN1)}, disponible restant ${euro(d1.disponibleRestant)}.`,
+    `- Declarant 1 : potentiel issu de l'avis ${euro(d1.totalDisponible)}, cotisations retenues ${euro(flow1.cotisationsRetenuesIr)}, disponible restant ${euro(flow1.disponibleRestant)}.`,
   ];
 
-  if (d2) {
-    lines.push(`- Declarant 2 : plafond calcule ${euro(d2.plafondCalculeN)}, reports ${euro(d2.nonUtiliseN3)} / ${euro(d2.nonUtiliseN2)} / ${euro(d2.nonUtiliseN1)}, disponible restant ${euro(d2.disponibleRestant)}.`);
+  if (d2 && flow2) {
+    lines.push(`- Declarant 2 : potentiel issu de l'avis ${euro(d2.totalDisponible)}, cotisations retenues ${euro(flow2.cotisationsRetenuesIr)}, disponible restant ${euro(flow2.disponibleRestant)}.`);
     lines.push(`- Mutualisation des plafonds (6QR) : ${yesNo(data.mutualisationConjoints)}.`);
   }
 
@@ -139,11 +141,11 @@ function buildMadelinBody(data: PerDeckData): string {
   }
 
   const lines = [
-    `- Declarant 1 : assiette ${euro(d1.assiette)}, enveloppe 15 % ${euro(d1.enveloppe15)}, enveloppe 10 % ${euro(d1.enveloppe10)}, disponible restant ${euro(d1.disponibleRestant)}.`,
+    `- Declarant 1 : assiette de versement ${euro(d1.assietteVersement)}, enveloppe 15 % ${euro(d1.enveloppe15Versement)}, enveloppe 10 % ${euro(d1.enveloppe10)}, reintegration ${euro(d1.surplusAReintegrer)}.`,
   ];
 
   if (d2) {
-    lines.push(`- Declarant 2 : assiette ${euro(d2.assiette)}, enveloppe 15 % ${euro(d2.enveloppe15)}, enveloppe 10 % ${euro(d2.enveloppe10)}, disponible restant ${euro(d2.disponibleRestant)}.`);
+    lines.push(`- Declarant 2 : assiette de versement ${euro(d2.assietteVersement)}, enveloppe 15 % ${euro(d2.enveloppe15Versement)}, enveloppe 10 % ${euro(d2.enveloppe10)}, reintegration ${euro(d2.surplusAReintegrer)}.`);
   }
 
   return lines.join('\n');
@@ -154,7 +156,7 @@ function buildDeclarationBody(data: PerDeckData): string {
   const lines = [
     `- 6NS : ${euro(boxes.case6NS)}.`,
     `- 6RS : ${euro(boxes.case6RS)}.`,
-    `- 6QS : ${euro(boxes.case6QS)}.`,
+    `- 6QS : ${euro(boxes.case6QS)} (flux Art. 83 / PERCO / Madelin retraite).`,
     `- 6OS : ${euro(boxes.case6OS)}.`,
   ];
 
@@ -172,6 +174,20 @@ function buildDeclarationBody(data: PerDeckData): string {
   }
 
   lines.push(`- 6QR : ${yesNo(boxes.case6QR)}.`);
+  return lines.join('\n');
+}
+
+function buildProjectionBody(data: PerDeckData): string {
+  const d1 = data.result.projectionAvisSuivant.declarant1;
+  const d2 = data.result.projectionAvisSuivant.declarant2;
+  const lines = [
+    `- Declarant 1 : reliquats ${euro(d1.nonUtiliseN2)} / ${euro(d1.nonUtiliseN1)} / ${euro(d1.nonUtiliseN)}, plafond calcule ${euro(d1.plafondCalculeN)}, total ${euro(d1.plafondTotal)}.`,
+  ];
+
+  if (d2) {
+    lines.push(`- Declarant 2 : reliquats ${euro(d2.nonUtiliseN2)} / ${euro(d2.nonUtiliseN1)} / ${euro(d2.nonUtiliseN)}, plafond calcule ${euro(d2.plafondCalculeN)}, total ${euro(d2.plafondTotal)}.`);
+  }
+
   return lines.join('\n');
 }
 
@@ -245,6 +261,12 @@ export function buildPerStudyDeck(
     title: 'Cases 2042 simulees',
     subtitle: 'Versements et mutualisation',
     body: buildDeclarationBody(data),
+  });
+  slides.push({
+    type: 'content',
+    title: 'Projection du prochain avis IR',
+    subtitle: 'Reliquats et plafond calculé',
+    body: buildProjectionBody(data),
   });
 
   if (data.mode === 'versement-n' && data.result.simulation) {


### PR DESCRIPTION
## Description
Correction de la page `/sim/per/potentiel` pour fiabiliser le calcul en tab `Revenus 2025` : barème IR du bon millésime, mutualisation effective des plafonds conjoint et consommation des plafonds alignée avec l’Excel.

## Changements
- Moteur PER : séparation des flux 2042, déduction 163 quatervicies, projection du prochain avis IR et détail Madelin 154 bis.
- Hook PER : résolution explicite du millésime de calcul (`current` / `previous`) selon l’année affichée et le parcours.
- UI PER : sidebar enrichie, modale d’information Madelin, libellés et rendu de la situation familiale ajustés.
- Exports : adaptation Excel/PPTX au nouveau `PerPotentielResult`.
- Tests : ajout de régressions sur barème Revenus 2025, mutualisation, ordre de consommation, flux 2042 et enveloppes Madelin.

## Fonctionnalités
- La tab `Revenus 2025` utilise le barème IR 2025 défini dans `/settings/impots`.
- La mutualisation réduit bien le plafond du conjoint qui cède du disponible.
- Les versements consomment d’abord le plafond de l’année, puis les reports les plus anciens.
- L’aperçu en direct affiche les cases 2042 et la projection du prochain avis IR de façon cohérente.

## Tests effectués
- [x] `npm run lint` passe
- [x] `npm run typecheck` passe
- [x] `npm test` passe
- [x] `npm run build` passe
- [x] `npm run check` passe (si utilisé comme agrégat)

## Notes
- Le classeur `SER1 - LAPLACE 2025.xlsm`, onglet `Synthèse décla`, a servi de référence pour la mutualisation et l’ordre de consommation.
- Pas de migration Supabase.
- Rollback : revert du commit `b356ff3`.

## Checklist
- [x] Pas de push direct sur `main` 
- [x] Pas de fichiers temporaires ajoutés à la racine
- [x] Documentation mise à jour si nécessaire