### PR TITLE
feat(per): affiner le parcours potentiel PER

### DIFF
--- a/src/engine/per/__tests__/perPotentiel.test.ts
+++ b/src/engine/per/__tests__/perPotentiel.test.ts
@@ -274,4 +274,60 @@ describe('calculatePerPotentiel', () => {
 
     expect(result.projectionAvisSuivant.declarant1.plafondCalculeN).toBe(4710);
   });
+
+  it('utilise le PASS 2026 en estimation 2026', () => {
+    const result = calculatePerPotentiel(makeInput({
+      mode: 'versement-n',
+      historicalBasis: 'previous-avis-plus-n1',
+      anneeRef: 2026,
+      yearKey: 'current',
+      situationFiscale: {
+        situationFamiliale: 'celibataire',
+        nombreParts: 1,
+        isole: false,
+        declarant1: makeDeclarant(),
+      },
+      projectionFiscale: {
+        situationFamiliale: 'celibataire',
+        nombreParts: 1,
+        isole: false,
+        declarant1: makeDeclarant(),
+      },
+      avisIr: makeAvis({ nonUtiliseAnnee1: 0, nonUtiliseAnnee2: 0, nonUtiliseAnnee3: 0, plafondCalcule: 0 }),
+      passHistory: {
+        2025: 47100,
+        2026: 48060,
+      },
+    }));
+
+    expect(result.projectionAvisSuivant.declarant1.plafondCalculeN).toBe(4806);
+  });
+
+  it('utilise le barème courant même quand les revenus saisis sont ceux de 2025', () => {
+    const taxSettings = {
+      ...DEFAULT_TAX_SETTINGS,
+      incomeTax: {
+        ...DEFAULT_TAX_SETTINGS.incomeTax,
+        scaleCurrent: [{ from: 0, to: null, rate: 0, deduction: 0 }],
+        scalePrevious: [{ from: 0, to: null, rate: 45, deduction: 0 }],
+      },
+    };
+    const input = makeInput({
+      anneeRef: 2025,
+      situationFiscale: {
+        situationFamiliale: 'celibataire',
+        nombreParts: 1,
+        isole: false,
+        declarant1: makeDeclarant({ salaires: 120000 }),
+      },
+      avisIr: makeAvis({ nonUtiliseAnnee1: 0, nonUtiliseAnnee2: 0, nonUtiliseAnnee3: 0, plafondCalcule: 0 }),
+      taxSettings,
+    });
+
+    const currentScaleResult = calculatePerPotentiel({ ...input, yearKey: 'current' });
+    const previousScaleResult = calculatePerPotentiel({ ...input, yearKey: 'previous' });
+
+    expect(currentScaleResult.situationFiscale.irEstime).toBe(0);
+    expect(previousScaleResult.situationFiscale.irEstime).toBeGreaterThan(0);
+  });
 });

--- a/src/features/per/components/potentiel/PerHypotheses.tsx
+++ b/src/features/per/components/potentiel/PerHypotheses.tsx
@@ -7,6 +7,7 @@ const PER_ASSUMPTIONS: string[] = [
   'Les versements obligatoires employeur (art. 83 / PERO / PEROB) viennent en déduction du plafond 163 quatervicies.',
   'La mutualisation des plafonds entre conjoints (case 6QR) suppose une imposition commune.',
   'Les revenus projetés pour l\'année en cours sont estimatifs et ne remplacent pas la déclaration définitive.',
+  'L’estimation 2026 utilise le dernier barème IR disponible dans Settings > Impôts (barème 2026 sur revenus 2025) ; elle devra être actualisée lorsque le barème suivant sera connu.',
   'Date limite de versement déductible : 31 décembre de l\'année fiscale en cours.',
 ];
 

--- a/src/features/per/components/potentiel/PerMadelinInfoModal.test.tsx
+++ b/src/features/per/components/potentiel/PerMadelinInfoModal.test.tsx
@@ -23,7 +23,7 @@ const zeroDetail = {
 };
 
 describe('PerMadelinInfoModal', () => {
-  it('affiche les lignes de détail même avec une base TNS non saisie', () => {
+  it('affiche uniquement le message d’absence de base TNS quand aucun revenu TNS n’est saisi', () => {
     const html = renderToStaticMarkup(
       <PerMadelinInfoModal
         declarant1={zeroDetail}
@@ -33,7 +33,8 @@ describe('PerMadelinInfoModal', () => {
     );
 
     expect(html).toContain('Aucune base TNS saisie');
-    expect(html).toContain('Assiette de versement');
-    expect(html).toContain('Enveloppe 10 % commune');
+    expect(html).not.toContain('Assiette de versement');
+    expect(html).not.toContain('Enveloppe 10 % commune');
+    expect(html).not.toContain('0 €');
   });
 });

--- a/src/features/per/components/potentiel/PerMadelinInfoModal.tsx
+++ b/src/features/per/components/potentiel/PerMadelinInfoModal.tsx
@@ -27,7 +27,7 @@ function MadelinDetailCard({
     return null;
   }
 
-  const showHint = detail.assietteVersement <= 0 && detail.cotisationsVersees <= 0;
+  const hasBaseTns = detail.assietteVersement > 0 || detail.assietteReport > 0;
 
   const rows = [
     ['Assiette de versement', detail.assietteVersement],
@@ -53,18 +53,18 @@ function MadelinDetailCard({
       </div>
 
       <div className="per-summary-breakdown-list">
-        {showHint && (
+        {!hasBaseTns ? (
           <div className="per-summary-breakdown-row per-summary-breakdown-row--muted">
             <span>Aucune base TNS saisie</span>
-            <strong>0 €</strong>
           </div>
+        ) : (
+          rows.map(([rowLabel, value]) => (
+            <div key={rowLabel} className="per-summary-breakdown-row">
+              <span>{rowLabel}</span>
+              <strong>{fmtCurrency(Number(value))}</strong>
+            </div>
+          ))
         )}
-        {rows.map(([rowLabel, value]) => (
-          <div key={rowLabel} className="per-summary-breakdown-row">
-            <span>{rowLabel}</span>
-            <strong>{fmtCurrency(Number(value))}</strong>
-          </div>
-        ))}
       </div>
     </div>
   );

--- a/src/features/per/components/potentiel/PerPotentielContextSidebar.test.tsx
+++ b/src/features/per/components/potentiel/PerPotentielContextSidebar.test.tsx
@@ -82,7 +82,7 @@ const result: PerPotentielResult = {
       reste15Versement: 0,
       reste15Report: 0,
       reste10: 0,
-      disponibleRestant: 0,
+      disponibleRestant: 999,
       surplusAReintegrer: 0,
       depassement: false,
     },
@@ -101,7 +101,7 @@ const result: PerPotentielResult = {
       reste15Versement: 0,
       reste15Report: 0,
       reste10: 0,
-      disponibleRestant: 0,
+      disponibleRestant: 888,
       surplusAReintegrer: 0,
       depassement: false,
     },
@@ -144,6 +144,8 @@ describe('PerPotentielContextSidebar', () => {
         step={3}
         isCouple
         showRevenusPreview
+        fiscalPreviewTitle="Synthèse déclaration IR 2026"
+        projectionPreviewTitle="Plafonds projetés"
         parcoursPills={[{ label: 'Avis IR 2025', on: true }]}
         totalAvisIrD1={11111}
         totalAvisIrD2={7777}
@@ -161,15 +163,25 @@ describe('PerPotentielContextSidebar', () => {
     expect(html).toContain('6NT');
     expect(html).toContain('Déclarant 1');
     expect(html).toContain('Déclarant 2');
-    expect((html.match(/Aperçu en direct/g) ?? []).length).toBe(1);
+    expect(html).toContain('Enveloppes Madelin N');
+    expect(html).toContain(fmtCurrency(999));
+    expect(html).toContain(fmtCurrency(888));
+    expect(html).not.toContain('D1 15 %');
+    expect(html).not.toContain('D1 10 %');
+    expect(html).not.toContain('D2 15 %');
+    expect(html).not.toContain('D2 10 %');
+    expect(html).toContain('Synthèse déclaration IR 2026');
+    expect(html).not.toContain('Aperçu en direct');
   });
 
-  it('keeps the split live preview outside the revenus step', () => {
+  it('keeps the split preview outside the revenus step with contextual titles', () => {
     const html = renderToStaticMarkup(
       <PerPotentielContextSidebar
         step={3}
         isCouple
         showRevenusPreview={false}
+        fiscalPreviewTitle="Estimation fiscale 2026"
+        projectionPreviewTitle="Plafonds projetés"
         parcoursPills={[{ label: 'Avis IR 2025', on: true }]}
         totalAvisIrD1={11111}
         totalAvisIrD2={7777}
@@ -177,7 +189,9 @@ describe('PerPotentielContextSidebar', () => {
       />,
     );
 
-    expect((html.match(/Aperçu en direct/g) ?? []).length).toBe(2);
+    expect(html).toContain('Estimation fiscale 2026');
+    expect(html).toContain('Plafonds projetés');
+    expect(html).not.toContain('Aperçu en direct');
     expect(html).toContain(fmtCurrency(11111));
   });
 });

--- a/src/features/per/components/potentiel/PerPotentielContextSidebar.tsx
+++ b/src/features/per/components/potentiel/PerPotentielContextSidebar.tsx
@@ -6,6 +6,8 @@ interface PerPotentielContextSidebarProps {
   step: WizardStep;
   isCouple: boolean;
   showRevenusPreview: boolean;
+  fiscalPreviewTitle: string;
+  projectionPreviewTitle: string;
   parcoursPills: Array<{ label: string; on: boolean }>;
   totalAvisIrD1: number;
   totalAvisIrD2: number;
@@ -22,7 +24,31 @@ const fmtCurrency = (value: number): string =>
 const fmtPercent = (value: number): string =>
   `${(value <= 1 ? value * 100 : value).toFixed(1)} %`;
 
-function MiniKpi({
+type MetricItem = {
+  label: string;
+  value: string;
+};
+
+function HeroDeclarantPair({
+  items,
+  compact = false,
+}: {
+  items: MetricItem[];
+  compact?: boolean;
+}): React.ReactElement {
+  return (
+    <div className={`per-potentiel-declarant-pair${compact ? ' per-potentiel-declarant-pair--compact' : ''}`}>
+      {items.map((item) => (
+        <div key={item.label} className="per-potentiel-declarant-metric">
+          <span className="per-potentiel-declarant-metric__label">{item.label}</span>
+          <strong className="per-potentiel-declarant-metric__value">{item.value}</strong>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SecondaryMetric({
   label,
   value,
 }: {
@@ -30,10 +56,27 @@ function MiniKpi({
   value: string;
 }): React.ReactElement {
   return (
-    <div className="per-potentiel-mini-kpi">
-      <span className="per-potentiel-mini-kpi-label">{label}</span>
-      <strong className="per-potentiel-mini-kpi-value">{value}</strong>
+    <div className="per-potentiel-secondary-metric">
+      <span className="per-potentiel-secondary-metric__label">{label}</span>
+      <strong className="per-potentiel-secondary-metric__value">{value}</strong>
     </div>
+  );
+}
+
+function CompactMetricList({
+  items,
+}: {
+  items: MetricItem[];
+}): React.ReactElement {
+  return (
+    <dl className="per-potentiel-compact-metrics">
+      {items.map((item) => (
+        <div key={item.label} className="per-potentiel-compact-metric">
+          <dt>{item.label}</dt>
+          <dd>{item.value}</dd>
+        </div>
+      ))}
+    </dl>
   );
 }
 
@@ -42,15 +85,35 @@ function PreviewColumn({
   items,
 }: {
   title: string;
-  items: Array<{ label: string; value: string }>;
+  items: MetricItem[];
 }): React.ReactElement {
   return (
     <div className="per-potentiel-preview-column">
       <div className="per-potentiel-preview-column__title">{title}</div>
-      <div className="per-potentiel-mini-kpis">
-        {items.map((item) => (
-          <MiniKpi key={`${title}-${item.label}`} label={item.label} value={item.value} />
-        ))}
+      <CompactMetricList items={items} />
+    </div>
+  );
+}
+
+function PreviewSection({
+  title,
+  isCouple,
+  declarant1,
+  declarant2,
+}: {
+  title: string;
+  isCouple: boolean;
+  declarant1: MetricItem[];
+  declarant2?: MetricItem[];
+}): React.ReactElement {
+  const hasDeclarant2 = isCouple && declarant2 && declarant2.length > 0;
+
+  return (
+    <div className="per-potentiel-preview-section">
+      <div className="per-potentiel-context-section__title">{title}</div>
+      <div className={`per-potentiel-preview-columns${hasDeclarant2 ? ' is-couple' : ''}`}>
+        <PreviewColumn title="Déclarant 1" items={declarant1} />
+        {hasDeclarant2 && <PreviewColumn title="Déclarant 2" items={declarant2} />}
       </div>
     </div>
   );
@@ -60,6 +123,8 @@ export function PerPotentielContextSidebar({
   step,
   isCouple,
   showRevenusPreview,
+  fiscalPreviewTitle,
+  projectionPreviewTitle,
   parcoursPills,
   totalAvisIrD1,
   totalAvisIrD2,
@@ -76,6 +141,20 @@ export function PerPotentielContextSidebar({
   const potentielLabel = showRevenusPreview
     ? '163 quatervicies disponible après saisie'
     : "163 quatervicies issu de l'avis IR";
+  const potentielItems = [
+    { label: 'Déclarant 1', value: fmtCurrency(potentielD1) },
+    ...((isCouple || potentielD2 > 0)
+      ? [{ label: 'Déclarant 2', value: fmtCurrency(potentielD2) }]
+      : []),
+  ];
+  const madelinItems = result?.plafondMadelin
+    ? [
+      { label: 'Déclarant 1', value: fmtCurrency(result.plafondMadelin.declarant1.disponibleRestant) },
+      ...(isCouple && result.plafondMadelin.declarant2
+        ? [{ label: 'Déclarant 2', value: fmtCurrency(result.plafondMadelin.declarant2.disponibleRestant) }]
+        : []),
+    ]
+    : [];
 
   const declarationD1 = result
     ? [
@@ -144,40 +223,14 @@ export function PerPotentielContextSidebar({
           {showPotentielAvis && (
             <div className="per-potentiel-context-item per-potentiel-context-item--avis">
               <span className="per-potentiel-context-label per-potentiel-context-label--small">{potentielLabel}</span>
-              <div className="per-potentiel-mini-kpis per-potentiel-mini-kpis--avis">
-                <MiniKpi label="Déclarant 1" value={fmtCurrency(potentielD1)} />
-                {(isCouple || potentielD2 > 0) && (
-                  <MiniKpi label="Déclarant 2" value={fmtCurrency(potentielD2)} />
-                )}
-              </div>
+              <HeroDeclarantPair items={potentielItems} />
             </div>
           )}
 
-          {result?.plafondMadelin && (
+          {madelinItems.length > 0 && (
             <div className="per-potentiel-context-item">
               <span className="per-potentiel-context-label per-potentiel-context-label--small">Enveloppes Madelin N</span>
-              <div className="per-potentiel-mini-kpis">
-                <MiniKpi
-                  label="D1 15 %"
-                  value={fmtCurrency(result.plafondMadelin.declarant1.enveloppe15Versement)}
-                />
-                <MiniKpi
-                  label="D1 10 %"
-                  value={fmtCurrency(result.plafondMadelin.declarant1.enveloppe10)}
-                />
-                {isCouple && result.plafondMadelin.declarant2 && (
-                  <>
-                    <MiniKpi
-                      label="D2 15 %"
-                      value={fmtCurrency(result.plafondMadelin.declarant2.enveloppe15Versement)}
-                    />
-                    <MiniKpi
-                      label="D2 10 %"
-                      value={fmtCurrency(result.plafondMadelin.declarant2.enveloppe10)}
-                    />
-                  </>
-                )}
-              </div>
+              <HeroDeclarantPair items={madelinItems} compact />
             </div>
           )}
         </div>
@@ -195,7 +248,7 @@ export function PerPotentielContextSidebar({
                     <line x1="6" y1="20" x2="6" y2="16" />
                   </svg>
                 </div>
-                <h3 className="sim-card__title">Aperçu en direct</h3>
+                <h3 className="sim-card__title">{fiscalPreviewTitle}</h3>
               </div>
               <div className="sim-divider sim-divider--tight" />
 
@@ -205,30 +258,26 @@ export function PerPotentielContextSidebar({
                   <div className="per-sidebar-hero__value">{fmtCurrency(result.situationFiscale.irEstime)}</div>
                 </div>
                 <div className="per-potentiel-mini-kpis-row">
-                  <MiniKpi label="TMI" value={fmtPercent(result.situationFiscale.tmi)} />
-                  <MiniKpi label="6QR" value={result.declaration2042.case6QR ? 'Oui' : 'Non'} />
+                  <SecondaryMetric label="TMI" value={fmtPercent(result.situationFiscale.tmi)} />
+                  <SecondaryMetric label="6QR" value={result.declaration2042.case6QR ? 'Oui' : 'Non'} />
                 </div>
               </div>
 
               <div className="sim-divider sim-divider--tight" />
-              <div className="per-potentiel-preview-section">
-                <div className="per-potentiel-context-section__title">Déclaration 2042</div>
-                <div className={`per-potentiel-preview-columns${isCouple ? ' is-couple' : ''}`}>
-                  <PreviewColumn title="Déclarant 1" items={declarationD1} />
-                  {isCouple && <PreviewColumn title="Déclarant 2" items={declarationD2} />}
-                </div>
-              </div>
+              <PreviewSection
+                title="Déclaration 2042"
+                isCouple={isCouple}
+                declarant1={declarationD1}
+                declarant2={declarationD2}
+              />
 
               <div className="sim-divider sim-divider--tight" />
-              <div className="per-potentiel-preview-section">
-                <div className="per-potentiel-context-section__title">Prochain avis IR</div>
-                <div className={`per-potentiel-preview-columns${isCouple && projectionD2.length > 0 ? ' is-couple' : ''}`}>
-                  <PreviewColumn title="Déclarant 1" items={projectionD1} />
-                  {isCouple && projectionD2.length > 0 && (
-                    <PreviewColumn title="Déclarant 2" items={projectionD2} />
-                  )}
-                </div>
-              </div>
+              <PreviewSection
+                title="Prochain avis IR"
+                isCouple={isCouple}
+                declarant1={projectionD1}
+                declarant2={projectionD2}
+              />
             </div>
           ) : (
             <>
@@ -241,7 +290,7 @@ export function PerPotentielContextSidebar({
                       <line x1="6" y1="20" x2="6" y2="16" />
                     </svg>
                   </div>
-                  <h3 className="sim-card__title">Aperçu en direct</h3>
+                  <h3 className="sim-card__title">{fiscalPreviewTitle}</h3>
                 </div>
                 <div className="sim-divider sim-divider--tight" />
 
@@ -250,30 +299,19 @@ export function PerPotentielContextSidebar({
                     <div className="per-sidebar-hero__label">IR estimé</div>
                     <div className="per-sidebar-hero__value">{fmtCurrency(result.situationFiscale.irEstime)}</div>
                   </div>
-                  <div className="per-potentiel-mini-kpis">
-                    <MiniKpi label="TMI" value={fmtPercent(result.situationFiscale.tmi)} />
-                    <MiniKpi label="6QR" value={result.declaration2042.case6QR ? 'Oui' : 'Non'} />
+                  <div className="per-potentiel-mini-kpis-row">
+                    <SecondaryMetric label="TMI" value={fmtPercent(result.situationFiscale.tmi)} />
+                    <SecondaryMetric label="6QR" value={result.declaration2042.case6QR ? 'Oui' : 'Non'} />
                   </div>
                 </div>
 
                 <div className="sim-divider sim-divider--tight" />
-                <div className="per-potentiel-context-section">
-                  <div className="per-potentiel-context-section__title">Déclaration 2042</div>
-                  <div className="per-potentiel-mini-kpis">
-                    <MiniKpi label="D1 6NS" value={fmtCurrency(result.declaration2042.case6NS)} />
-                    <MiniKpi label="D1 6RS" value={fmtCurrency(result.declaration2042.case6RS)} />
-                    <MiniKpi label="D1 6OS" value={fmtCurrency(result.declaration2042.case6OS)} />
-                    <MiniKpi label="D1 6QS" value={fmtCurrency(result.declaration2042.case6QS)} />
-                    {isCouple && typeof result.declaration2042.case6NT === 'number' && (
-                      <>
-                        <MiniKpi label="D2 6NT" value={fmtCurrency(result.declaration2042.case6NT)} />
-                        <MiniKpi label="D2 6RT" value={fmtCurrency(result.declaration2042.case6RT ?? 0)} />
-                        <MiniKpi label="D2 6OT" value={fmtCurrency(result.declaration2042.case6OT ?? 0)} />
-                        <MiniKpi label="D2 6QT" value={fmtCurrency(result.declaration2042.case6QT ?? 0)} />
-                      </>
-                    )}
-                  </div>
-                </div>
+                <PreviewSection
+                  title="Déclaration 2042"
+                  isCouple={isCouple}
+                  declarant1={declarationD1}
+                  declarant2={declarationD2}
+                />
               </div>
 
               <div className="premium-card per-potentiel-context-card sim-summary-card sim-summary-card--secondary">
@@ -286,28 +324,15 @@ export function PerPotentielContextSidebar({
                       <path d="M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Z" />
                     </svg>
                   </div>
-                  <h3 className="sim-card__title">Aperçu en direct</h3>
+                  <h3 className="sim-card__title">{projectionPreviewTitle}</h3>
                 </div>
                 <div className="sim-divider sim-divider--tight" />
-                <div className="per-potentiel-context-section">
-                  <div className="per-potentiel-context-section__title">Prochain avis IR</div>
-                  <div className="per-potentiel-mini-kpis">
-                    <MiniKpi label="D1 reliquat N-2" value={fmtCurrency(result.projectionAvisSuivant.declarant1.nonUtiliseN2)} />
-                    <MiniKpi label="D1 reliquat N-1" value={fmtCurrency(result.projectionAvisSuivant.declarant1.nonUtiliseN1)} />
-                    <MiniKpi label="D1 reliquat N" value={fmtCurrency(result.projectionAvisSuivant.declarant1.nonUtiliseN)} />
-                    <MiniKpi label="D1 plafond calculé" value={fmtCurrency(result.projectionAvisSuivant.declarant1.plafondCalculeN)} />
-                    <MiniKpi label="D1 total" value={fmtCurrency(result.projectionAvisSuivant.declarant1.plafondTotal)} />
-                    {isCouple && result.projectionAvisSuivant.declarant2 && (
-                      <>
-                        <MiniKpi label="D2 reliquat N-2" value={fmtCurrency(result.projectionAvisSuivant.declarant2.nonUtiliseN2)} />
-                        <MiniKpi label="D2 reliquat N-1" value={fmtCurrency(result.projectionAvisSuivant.declarant2.nonUtiliseN1)} />
-                        <MiniKpi label="D2 reliquat N" value={fmtCurrency(result.projectionAvisSuivant.declarant2.nonUtiliseN)} />
-                        <MiniKpi label="D2 plafond calculé" value={fmtCurrency(result.projectionAvisSuivant.declarant2.plafondCalculeN)} />
-                        <MiniKpi label="D2 total" value={fmtCurrency(result.projectionAvisSuivant.declarant2.plafondTotal)} />
-                      </>
-                    )}
-                  </div>
-                </div>
+                <PreviewSection
+                  title="Prochain avis IR"
+                  isCouple={isCouple}
+                  declarant1={projectionD1}
+                  declarant2={projectionD2}
+                />
               </div>
             </>
           )}

--- a/src/features/per/components/potentiel/PerPotentielSimulator.test.tsx
+++ b/src/features/per/components/potentiel/PerPotentielSimulator.test.tsx
@@ -70,7 +70,13 @@ vi.mock('./steps/AvisIrStep', () => ({
 }));
 
 vi.mock('./steps/SituationFiscaleStep', () => ({
-  default: () => <div>Situation step</div>,
+  default: ({
+    showFoyerCard,
+    situationFamiliale,
+  }: {
+    showFoyerCard: boolean;
+    situationFamiliale: 'celibataire' | 'marie';
+  }) => <div>Situation step {showFoyerCard ? 'foyer visible' : 'foyer masqué'} {situationFamiliale}</div>,
 }));
 
 vi.mock('./steps/SynthesePotentielStep', () => ({
@@ -121,6 +127,12 @@ function makeHookState(step: number) {
     nombreParts: 1,
     isole: false,
     children: [],
+    projectionSituationFamiliale: 'celibataire',
+    projectionNombreParts: 1,
+    projectionIsole: false,
+    projectionChildren: [],
+    projectionMutualisationConjoints: false,
+    projectionFoyerEdited: false,
     revenusN1Declarant1: { statutTns: false },
     revenusN1Declarant2: { statutTns: false },
     projectionNDeclarant1: { statutTns: false },
@@ -170,16 +182,21 @@ function makeHookReturn(step: number) {
         },
       }
       : null,
-    visibleSteps: [1, 2, 3, 5],
+    visibleSteps: [1, 2, 3],
     setMode: vi.fn(),
     setHistoricalBasis: vi.fn(),
     setNeedsCurrentYearEstimate: vi.fn(),
     updateAvisIr: vi.fn(),
     updateSituation: vi.fn(),
+    updateProjectionSituation: vi.fn(),
     updateDeclarant: vi.fn(),
+    updateDeclarants: vi.fn(),
     addChild: vi.fn(),
+    addProjectionChild: vi.fn(),
     updateChildMode: vi.fn(),
+    updateProjectionChildMode: vi.fn(),
     removeChild: vi.fn(),
+    removeProjectionChild: vi.fn(),
     setVersementEnvisage: vi.fn(),
     nextStep: vi.fn(),
     prevStep: vi.fn(),
@@ -227,12 +244,49 @@ describe('PerPotentielSimulator', () => {
         historicalBasis: 'current-avis',
         needsCurrentYearEstimate: true,
       },
-      visibleSteps: [1, 2, 3, 4, 5],
+      visibleSteps: [1, 2, 3, 4],
     });
 
     const html = renderToStaticMarkup(<PerPotentielSimulator />);
 
     expect(html).toContain('Sidebar contexte 11000 / 7000');
+  });
+
+  it('affiche une situation familiale distincte sur l’estimation 2026', () => {
+    mockUsePerPotentiel.mockReturnValue({
+      ...makeHookReturn(4),
+      state: {
+        ...makeHookState(4),
+        needsCurrentYearEstimate: true,
+        projectionSituationFamiliale: 'marie',
+        projectionNombreParts: 2,
+        projectionIsole: false,
+        projectionMutualisationConjoints: true,
+        projectionFoyerEdited: true,
+      },
+      visibleSteps: [1, 2, 3, 4],
+    });
+
+    const html = renderToStaticMarkup(<PerPotentielSimulator />);
+
+    expect(html).toContain('Situation step foyer visible marie');
+  });
+
+  it('renomme la tab déclaration en Revenus 2025 et masque la synthèse', () => {
+    mockUsePerPotentiel.mockReturnValue({
+      ...makeHookReturn(3),
+      state: {
+        ...makeHookState(3),
+        mode: 'declaration-n1',
+      },
+      visibleSteps: [1, 2, 3],
+    });
+
+    const html = renderToStaticMarkup(<PerPotentielSimulator />);
+
+    expect(html).toContain('Revenus 2025');
+    expect(html).not.toContain('>Déclaration<');
+    expect(html).not.toContain('Synthèse');
   });
 
   it('uses the shared title row pattern for stage headers', () => {

--- a/src/features/per/components/potentiel/PerPotentielSimulator.tsx
+++ b/src/features/per/components/potentiel/PerPotentielSimulator.tsx
@@ -17,11 +17,9 @@ import { getPerWorkflowYears } from '../../utils/perWorkflowYears';
 import ModeStep from './steps/ModeStep';
 import AvisIrStep from './steps/AvisIrStep';
 import SituationFiscaleStep from './steps/SituationFiscaleStep';
-import SynthesePotentielStep from './steps/SynthesePotentielStep';
 import type { PerAbattementConfig, PerIncomeFilters } from './steps/PerIncomeTable';
 import { PerHypotheses } from './PerHypotheses';
 import { PerPotentielContextSidebar } from './PerPotentielContextSidebar';
-import { PerSynthesisSidebar } from './PerSynthesisSidebar';
 import '../../styles/index.css';
 
 type StepMeta = {
@@ -67,7 +65,7 @@ function getStepMeta(
     case 3:
       if (mode === 'declaration-n1') {
         return {
-          shortLabel: 'Déclaration',
+          shortLabel: `Revenus ${years.currentIncomeYear}`,
           title: `Revenus ${years.currentIncomeYear} et versements à déclarer`,
         };
       }
@@ -111,14 +109,17 @@ export default function PerPotentielSimulator(): React.ReactElement {
     setNeedsCurrentYearEstimate,
     updateAvisIr,
     updateSituation,
+    updateProjectionSituation,
     updateDeclarant,
+    updateDeclarants,
     addChild,
+    addProjectionChild,
     updateChildMode,
+    updateProjectionChildMode,
     removeChild,
-    setVersementEnvisage,
+    removeProjectionChild,
     goToStep,
     reset,
-    isCouple,
   } = usePerPotentiel(fiscalContext);
 
   useEffect(() => {
@@ -161,8 +162,8 @@ export default function PerPotentielSimulator(): React.ReactElement {
   const activeStep = getStepMeta(state.step, state.mode, state.historicalBasis, years);
   const stepIndex = visibleSteps.indexOf(state.step);
   const exportOptions = [
-    { label: 'Excel', onClick: exportExcel, disabled: !result || state.step !== 5 },
-    { label: 'PowerPoint', onClick: exportPowerPoint, disabled: !result || state.step !== 5 },
+    { label: 'Excel', onClick: exportExcel, disabled: !result },
+    { label: 'PowerPoint', onClick: exportPowerPoint, disabled: !result },
   ];
 
   // Pills parcours dans la sidebar
@@ -192,6 +193,14 @@ export default function PerPotentielSimulator(): React.ReactElement {
   const parcoursPills = buildPills();
   const totalAvisIrD1 = sumAvisIrPlafonds(state.avisIr);
   const totalAvisIrD2 = sumAvisIrPlafonds(state.avisIr2);
+  const revenusIsCouple = state.situationFamiliale === 'marie';
+  const projectionIsCouple = state.projectionSituationFamiliale === 'marie';
+  const usesProjectionFoyer = state.mode === 'versement-n' && (
+    state.historicalBasis === 'current-avis'
+      ? state.step >= 3
+      : state.needsCurrentYearEstimate && state.step >= 4
+  );
+  const activeIsCouple = usesProjectionFoyer ? projectionIsCouple : revenusIsCouple;
   const abat10CfgRoot = fiscalContext._raw_tax?.incomeTax?.abat10 ?? {};
   const abat10SalCfgCurrent: PerAbattementConfig = abat10CfgRoot.current ?? {};
   const abat10RetCfgCurrent: PerAbattementConfig = abat10CfgRoot.retireesCurrent ?? {};
@@ -200,6 +209,10 @@ export default function PerPotentielSimulator(): React.ReactElement {
       state.mode === 'declaration-n1'
       || (state.mode === 'versement-n' && state.historicalBasis === 'previous-avis-plus-n1')
     );
+  const fiscalPreviewTitle = isRevenusStep
+    ? `Synthèse déclaration IR ${years.currentTaxYear}`
+    : `Estimation fiscale ${years.currentTaxYear}`;
+  const projectionPreviewTitle = 'Plafonds projetés';
 
   const avisBasis = state.mode === 'declaration-n1'
     ? 'previous-avis-plus-n1'
@@ -298,7 +311,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   situationFamiliale={state.situationFamiliale}
                   isole={state.isole}
                   children={state.children}
-                  isCouple={isCouple}
+                  isCouple={revenusIsCouple}
                   mutualisationConjoints={state.mutualisationConjoints}
                   declarant1={state.revenusN1Declarant1}
                   declarant2={state.revenusN1Declarant2}
@@ -312,6 +325,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   onRemoveChild={removeChild}
                   onToggleIncomeFilter={toggleIncomeFilter}
                   onUpdateDeclarant={(decl, patch) => updateDeclarant('revenus-n1', decl, patch)}
+                  onUpdateDeclarants={(patches) => updateDeclarants('revenus-n1', patches)}
                 />
               )}
 
@@ -323,7 +337,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   situationFamiliale={state.situationFamiliale}
                   isole={state.isole}
                   children={state.children}
-                  isCouple={isCouple}
+                  isCouple={revenusIsCouple}
                   mutualisationConjoints={state.mutualisationConjoints}
                   declarant1={state.revenusN1Declarant1}
                   declarant2={state.revenusN1Declarant2}
@@ -337,6 +351,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   onRemoveChild={removeChild}
                   onToggleIncomeFilter={toggleIncomeFilter}
                   onUpdateDeclarant={(decl, patch) => updateDeclarant('revenus-n1', decl, patch)}
+                  onUpdateDeclarants={(patches) => updateDeclarants('revenus-n1', patches)}
                 />
               )}
 
@@ -345,23 +360,24 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   variant="versements-n"
                   yearLabel={`${years.currentTaxYear}`}
                   showFoyerCard
-                  situationFamiliale={state.situationFamiliale}
-                  isole={state.isole}
-                  children={state.children}
-                  isCouple={isCouple}
-                  mutualisationConjoints={state.mutualisationConjoints}
+                  situationFamiliale={state.projectionSituationFamiliale}
+                  isole={state.projectionIsole}
+                  children={state.projectionChildren}
+                  isCouple={projectionIsCouple}
+                  mutualisationConjoints={state.projectionMutualisationConjoints}
                   declarant1={state.projectionNDeclarant1}
                   declarant2={state.projectionNDeclarant2}
                   plafondMadelin={result?.plafondMadelin}
                   incomeFilters={incomeFilters}
                   abat10SalCfg={abat10SalCfgCurrent}
                   abat10RetCfg={abat10RetCfgCurrent}
-                  onUpdateSituation={updateSituation}
-                  onAddChild={addChild}
-                  onUpdateChildMode={updateChildMode}
-                  onRemoveChild={removeChild}
+                  onUpdateSituation={updateProjectionSituation}
+                  onAddChild={addProjectionChild}
+                  onUpdateChildMode={updateProjectionChildMode}
+                  onRemoveChild={removeProjectionChild}
                   onToggleIncomeFilter={toggleIncomeFilter}
                   onUpdateDeclarant={(decl, patch) => updateDeclarant('projection-n', decl, patch)}
+                  onUpdateDeclarants={(patches) => updateDeclarants('projection-n', patches)}
                 />
               )}
 
@@ -369,33 +385,28 @@ export default function PerPotentielSimulator(): React.ReactElement {
                 <SituationFiscaleStep
                   variant="projection-n"
                   yearLabel={`${years.currentTaxYear}`}
-                  showFoyerCard={false}
-                  situationFamiliale={state.situationFamiliale}
-                  isole={state.isole}
-                  children={state.children}
-                  isCouple={isCouple}
-                  mutualisationConjoints={state.mutualisationConjoints}
+                  showFoyerCard
+                  situationFamiliale={state.projectionSituationFamiliale}
+                  isole={state.projectionIsole}
+                  children={state.projectionChildren}
+                  isCouple={projectionIsCouple}
+                  mutualisationConjoints={state.projectionMutualisationConjoints}
                   declarant1={state.projectionNDeclarant1}
                   declarant2={state.projectionNDeclarant2}
                   plafondMadelin={result?.plafondMadelin}
                   incomeFilters={incomeFilters}
                   abat10SalCfg={abat10SalCfgCurrent}
                   abat10RetCfg={abat10RetCfgCurrent}
-                  onUpdateSituation={updateSituation}
-                  onAddChild={addChild}
-                  onUpdateChildMode={updateChildMode}
-                  onRemoveChild={removeChild}
+                  onUpdateSituation={updateProjectionSituation}
+                  onAddChild={addProjectionChild}
+                  onUpdateChildMode={updateProjectionChildMode}
+                  onRemoveChild={removeProjectionChild}
                   onToggleIncomeFilter={toggleIncomeFilter}
                   onUpdateDeclarant={(decl, patch) => updateDeclarant('projection-n', decl, patch)}
+                  onUpdateDeclarants={(patches) => updateDeclarants('projection-n', patches)}
                 />
               )}
 
-              {state.step === 5 && (
-                <SynthesePotentielStep
-                  result={result}
-                  isCouple={isCouple}
-                />
-              )}
             </div>
 
           </div>
@@ -404,26 +415,17 @@ export default function PerPotentielSimulator(): React.ReactElement {
 
         {state.mode !== null && (
         <aside className="per-potentiel-context sim-grid__col sim-grid__col--sticky">
-          {state.step !== 5 && (
-            <PerPotentielContextSidebar
-              step={state.step}
-              isCouple={isCouple}
-              showRevenusPreview={isRevenusStep}
-              parcoursPills={parcoursPills}
-              totalAvisIrD1={totalAvisIrD1}
-              totalAvisIrD2={totalAvisIrD2}
-              result={result}
-            />
-          )}
-
-          {result && state.step === 5 && (
-            <PerSynthesisSidebar
-              result={result}
-              modeVersement={state.mode === 'versement-n'}
-              versementEnvisage={state.versementEnvisage}
-              onSetVersement={setVersementEnvisage}
-            />
-          )}
+          <PerPotentielContextSidebar
+            step={state.step}
+            isCouple={activeIsCouple}
+            showRevenusPreview={isRevenusStep}
+            fiscalPreviewTitle={fiscalPreviewTitle}
+            projectionPreviewTitle={projectionPreviewTitle}
+            parcoursPills={parcoursPills}
+            totalAvisIrD1={totalAvisIrD1}
+            totalAvisIrD2={totalAvisIrD2}
+            result={result}
+          />
         </aside>
         )}
       </div>

--- a/src/features/per/components/potentiel/steps/PerIncomeTable.tsx
+++ b/src/features/per/components/potentiel/steps/PerIncomeTable.tsx
@@ -4,6 +4,7 @@ import { SimSelect } from '@/components/ui/sim/SimSelect';
 import { computeAbattement10 } from '../../../../../engine/ir/abattement10';
 import type { DeclarantRevenus } from '../../../../../engine/per';
 import { formatInteger } from '../../../../../utils/formatNumber';
+import type { PerDeclarantPatch } from '../../../hooks/usePerPotentiel';
 import { PerAmountInput } from '../PerAmountInput';
 
 export type PerIncomeFilters = {
@@ -153,6 +154,24 @@ function buildTnsTogglePatch(enabled: boolean): Partial<DeclarantRevenus> {
   };
 }
 
+export function buildTnsFoyerTogglePatches({
+  isCouple,
+  declarant1,
+  declarant2,
+}: {
+  isCouple: boolean;
+  declarant1: DeclarantRevenus;
+  declarant2: DeclarantRevenus;
+}): PerDeclarantPatch[] {
+  const isActive = declarant1.statutTns || (isCouple && declarant2.statutTns);
+  const patch = buildTnsTogglePatch(!isActive);
+
+  return [
+    { decl: 1 as const, patch },
+    ...(isCouple ? [{ decl: 2 as const, patch }] : []),
+  ];
+}
+
 function DividerRow({ isCouple }: { isCouple: boolean }): React.ReactElement {
   return (
     <tr className="per-divider-row">
@@ -172,6 +191,7 @@ export function PerIncomeTable({
   abat10RetCfg,
   onToggleIncomeFilter,
   onUpdateDeclarant,
+  onUpdateDeclarants,
 }: {
   isCouple: boolean;
   declarant1: DeclarantRevenus;
@@ -181,10 +201,14 @@ export function PerIncomeTable({
   abat10RetCfg: PerAbattementConfig;
   onToggleIncomeFilter: (_key: keyof PerIncomeFilters) => void;
   onUpdateDeclarant: (_decl: 1 | 2, _patch: Partial<DeclarantRevenus>) => void;
+  onUpdateDeclarants: (_patches: PerDeclarantPatch[]) => void;
 }): React.ReactElement {
-  const showTnsRows = declarant1.statutTns || declarant2.statutTns;
+  const showTnsRows = declarant1.statutTns || (isCouple && declarant2.statutTns);
   const showPensionRows = incomeFilters.pension === true;
   const showFoncierRow = incomeFilters.foncier === true;
+  const toggleTns = () => {
+    onUpdateDeclarants(buildTnsFoyerTogglePatches({ isCouple, declarant1, declarant2 }));
+  };
 
   const abat10SalD1 = computeAbattement10(
     (declarant1.salaires || 0) + (declarant1.art62 || 0),
@@ -209,24 +233,13 @@ export function PerIncomeTable({
           <div className="per-income-filters" role="group" aria-label="Filtres des lignes de revenus imposables">
             <button
               type="button"
-              className={`per-income-filter-btn${declarant1.statutTns ? ' is-active' : ''}`}
-              onClick={() => onUpdateDeclarant(1, buildTnsTogglePatch(!declarant1.statutTns))}
-              aria-pressed={declarant1.statutTns}
-              data-testid="per-toggle-tns-d1"
+              className={`per-income-filter-btn${showTnsRows ? ' is-active' : ''}`}
+              onClick={toggleTns}
+              aria-pressed={showTnsRows}
+              data-testid="per-toggle-tns"
             >
-              D1 TNS
+              TNS
             </button>
-            {isCouple && (
-              <button
-                type="button"
-                className={`per-income-filter-btn${declarant2.statutTns ? ' is-active' : ''}`}
-                onClick={() => onUpdateDeclarant(2, buildTnsTogglePatch(!declarant2.statutTns))}
-                aria-pressed={declarant2.statutTns}
-                data-testid="per-toggle-tns-d2"
-              >
-                D2 TNS
-              </button>
-            )}
             <button
               type="button"
               className={`per-income-filter-btn${showPensionRows ? ' is-active' : ''}`}

--- a/src/features/per/components/potentiel/steps/SituationFiscaleStep.test.tsx
+++ b/src/features/per/components/potentiel/steps/SituationFiscaleStep.test.tsx
@@ -1,6 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 import SituationFiscaleStep from './SituationFiscaleStep';
+import { buildTnsFoyerTogglePatches } from './PerIncomeTable';
 
 const baseDeclarant = {
   statutTns: false,
@@ -41,6 +42,7 @@ const baseProps = {
   onRemoveChild: vi.fn(),
   onToggleIncomeFilter: vi.fn(),
   onUpdateDeclarant: vi.fn(),
+  onUpdateDeclarants: vi.fn(),
 };
 
 describe('SituationFiscaleStep', () => {
@@ -85,7 +87,9 @@ describe('SituationFiscaleStep', () => {
       />,
     );
 
-    expect(html).toContain('D1 TNS');
+    expect(html).toContain('TNS');
+    expect(html).not.toContain('D1 TNS');
+    expect(html).not.toContain('D2 TNS');
     expect(html).toContain('Pension');
     expect(html).toContain('Foncier');
     expect(html).toContain('Revenus des associés / gérants');
@@ -108,5 +112,45 @@ describe('SituationFiscaleStep', () => {
     expect(html).toContain('contribue à 6QS / 6QT');
     expect(html).toContain('nécessaire pour le calcul de l');
     expect(html).toContain('Afficher le détail des enveloppes Madelin 154 bis');
+  });
+
+  it('builds a global TNS toggle patch for the whole foyer', () => {
+    expect(buildTnsFoyerTogglePatches({
+      isCouple: true,
+      declarant1: baseDeclarant,
+      declarant2: baseDeclarant,
+    })).toEqual([
+      { decl: 1, patch: { statutTns: true } },
+      { decl: 2, patch: { statutTns: true } },
+    ]);
+
+    expect(buildTnsFoyerTogglePatches({
+      isCouple: true,
+      declarant1: { ...baseDeclarant, statutTns: false },
+      declarant2: { ...baseDeclarant, statutTns: true, bic: 50_000 },
+    })).toEqual([
+      {
+        decl: 1,
+        patch: {
+          statutTns: false,
+          art62: 0,
+          bic: 0,
+          cotisationsMadelin154bis: 0,
+          cotisationsMadelinRetraite: 0,
+          cotisationsPrevo: 0,
+        },
+      },
+      {
+        decl: 2,
+        patch: {
+          statutTns: false,
+          art62: 0,
+          bic: 0,
+          cotisationsMadelin154bis: 0,
+          cotisationsMadelinRetraite: 0,
+          cotisationsPrevo: 0,
+        },
+      },
+    ]);
   });
 });

--- a/src/features/per/components/potentiel/steps/SituationFiscaleStep.tsx
+++ b/src/features/per/components/potentiel/steps/SituationFiscaleStep.tsx
@@ -5,6 +5,7 @@
 import React, { useState } from 'react';
 import { SimSelect } from '@/components/ui/sim/SimSelect';
 import type { DeclarantRevenus, PlafondMadelinDetail } from '../../../../../engine/per';
+import type { PerDeclarantPatch } from '../../../hooks/usePerPotentiel';
 import type { PerChildDraft } from '../../../utils/perParts';
 import { PerAmountInput } from '../PerAmountInput';
 import { PerMadelinInfoModal } from '../PerMadelinInfoModal';
@@ -45,6 +46,7 @@ interface SituationFiscaleStepProps {
   onRemoveChild: (_id: number) => void;
   onToggleIncomeFilter: (_key: keyof PerIncomeFilters) => void;
   onUpdateDeclarant: (_decl: 1 | 2, _patch: Partial<DeclarantRevenus>) => void;
+  onUpdateDeclarants: (_patches: PerDeclarantPatch[]) => void;
 }
 
 type ContributionFieldKey =
@@ -77,6 +79,7 @@ export default function SituationFiscaleStep({
   onRemoveChild,
   onToggleIncomeFilter,
   onUpdateDeclarant,
+  onUpdateDeclarants,
 }: SituationFiscaleStepProps): React.ReactElement {
   const [showMadelinInfo, setShowMadelinInfo] = useState(false);
   const showTnsContributionRows = declarant1.statutTns || declarant2.statutTns;
@@ -188,6 +191,7 @@ export default function SituationFiscaleStep({
         abat10RetCfg={abat10RetCfg}
         onToggleIncomeFilter={onToggleIncomeFilter}
         onUpdateDeclarant={onUpdateDeclarant}
+        onUpdateDeclarants={onUpdateDeclarants}
       />
 
       <div className="premium-card premium-card--guide sim-card--guide per-contribution-card">

--- a/src/features/per/hooks/usePerPotentiel.ts
+++ b/src/features/per/hooks/usePerPotentiel.ts
@@ -16,15 +16,24 @@ import type {
 } from '../../../engine/per';
 import type { FiscalContext } from '../../../hooks/useFiscalContext';
 import { getAvisReferenceYears, getPerWorkflowYears } from '../utils/perWorkflowYears';
-import { derivePerNombreParts, type PerChildDraft } from '../utils/perParts';
+import type { PerChildDraft } from '../utils/perParts';
 import { shouldUseProjectionForCalculation } from '../utils/perProjectionScope';
 import { resolvePerCalculationYear } from '../utils/perCalculationYear';
+import { projectionToAvisIrPlafonds } from '../utils/perSyntheticAvis';
+import { getNextPerChildId, normalizePerChildren, normalizePerFoyer } from '../utils/perFoyerState';
+import { buildVisibleSteps } from '../utils/perVisibleSteps';
 
 const SESSION_KEY = 'ser1:sim:per:potentiel:v4';
 
 export type PerMode = 'versement-n' | 'declaration-n1';
 export type WizardStep = 1 | 2 | 3 | 4 | 5;
 export type PerDeclarantScope = 'revenus-n1' | 'projection-n';
+export type PerDeclarantPatch = { decl: 1 | 2; patch: Partial<DeclarantRevenus> };
+type PerSituationPatch = Partial<{
+  situationFamiliale: 'celibataire' | 'marie';
+  isole: boolean;
+  mutualisationConjoints: boolean;
+}>;
 
 export interface PerPotentielState {
   step: WizardStep;
@@ -37,6 +46,12 @@ export interface PerPotentielState {
   nombreParts: number;
   isole: boolean;
   children: PerChildDraft[];
+  projectionSituationFamiliale: 'celibataire' | 'marie';
+  projectionNombreParts: number;
+  projectionIsole: boolean;
+  projectionChildren: PerChildDraft[];
+  projectionMutualisationConjoints: boolean;
+  projectionFoyerEdited: boolean;
   revenusN1Declarant1: DeclarantRevenus;
   revenusN1Declarant2: DeclarantRevenus;
   projectionNDeclarant1: DeclarantRevenus;
@@ -64,40 +79,39 @@ const EMPTY_DECLARANT: DeclarantRevenus = {
   cotisationsPrevo: 0,
 };
 
-function normalizeChildren(children: PerChildDraft[] | null | undefined): PerChildDraft[] {
-  return Array.isArray(children)
-    ? children
-      .filter((child): child is PerChildDraft => Boolean(child) && (child.mode === 'charge' || child.mode === 'shared'))
-      .map((child, index) => ({
-        id: Number.isFinite(child.id) ? child.id : index + 1,
-        mode: child.mode,
-      }))
-    : [];
-}
-
 function normalizeState(state: PerPotentielState): PerPotentielState {
-  const situationFamiliale = state.situationFamiliale;
-  const children = normalizeChildren(state.children);
-  const isole = situationFamiliale === 'marie' ? false : state.isole;
-  const mutualisationConjoints = situationFamiliale === 'marie'
-    ? state.mutualisationConjoints
-    : false;
+  const visibleSteps = buildVisibleSteps(state.mode, state.needsCurrentYearEstimate);
+  const fallbackStep = visibleSteps[visibleSteps.length - 1] ?? 1;
+  const step = visibleSteps.includes(state.step) ? state.step : fallbackStep;
+  const foyer = normalizePerFoyer({
+    situationFamiliale: state.situationFamiliale,
+    isole: state.isole,
+    children: state.children,
+    mutualisationConjoints: state.mutualisationConjoints,
+  });
+  const projectionFoyer = state.projectionFoyerEdited
+    ? normalizePerFoyer({
+      situationFamiliale: state.projectionSituationFamiliale,
+      isole: state.projectionIsole,
+      children: state.projectionChildren,
+      mutualisationConjoints: state.projectionMutualisationConjoints,
+    })
+    : foyer;
 
   return {
     ...state,
-    isole,
-    children,
-    mutualisationConjoints,
-    nombreParts: derivePerNombreParts({
-      situationFamiliale,
-      isole,
-      children,
-    }),
+    step,
+    situationFamiliale: foyer.situationFamiliale,
+    isole: foyer.isole,
+    children: foyer.children,
+    mutualisationConjoints: foyer.mutualisationConjoints,
+    nombreParts: foyer.nombreParts,
+    projectionSituationFamiliale: projectionFoyer.situationFamiliale,
+    projectionIsole: projectionFoyer.isole,
+    projectionChildren: projectionFoyer.children,
+    projectionMutualisationConjoints: projectionFoyer.mutualisationConjoints,
+    projectionNombreParts: projectionFoyer.nombreParts,
   };
-}
-
-function getNextChildId(children: PerChildDraft[]): number {
-  return children.reduce((maxId, child) => Math.max(maxId, child.id), 0) + 1;
 }
 
 function makeDefaultState(): PerPotentielState {
@@ -112,6 +126,12 @@ function makeDefaultState(): PerPotentielState {
     nombreParts: 1,
     isole: false,
     children: [],
+    projectionSituationFamiliale: 'celibataire',
+    projectionNombreParts: 1,
+    projectionIsole: false,
+    projectionChildren: [],
+    projectionMutualisationConjoints: false,
+    projectionFoyerEdited: false,
     revenusN1Declarant1: { ...EMPTY_DECLARANT },
     revenusN1Declarant2: { ...EMPTY_DECLARANT },
     projectionNDeclarant1: { ...EMPTY_DECLARANT },
@@ -136,7 +156,8 @@ function loadSession(): PerPotentielState | null {
       revenusN1Declarant2: { ...EMPTY_DECLARANT, ...parsed.revenusN1Declarant2 },
       projectionNDeclarant1: { ...EMPTY_DECLARANT, ...parsed.projectionNDeclarant1 },
       projectionNDeclarant2: { ...EMPTY_DECLARANT, ...parsed.projectionNDeclarant2 },
-      children: normalizeChildren(parsed.children),
+      children: normalizePerChildren(parsed.children),
+      projectionChildren: normalizePerChildren(parsed.projectionChildren),
     });
   } catch {
     return null;
@@ -154,33 +175,27 @@ function saveSession(state: PerPotentielState): void {
 function buildSituationInput(
   state: PerPotentielState,
   scope: PerDeclarantScope,
-  isCouple: boolean,
 ): PerPotentielInput['situationFiscale'] {
   const declarant1 = scope === 'revenus-n1' ? state.revenusN1Declarant1 : state.projectionNDeclarant1;
   const declarant2 = scope === 'revenus-n1' ? state.revenusN1Declarant2 : state.projectionNDeclarant2;
+  const situationFamiliale = scope === 'revenus-n1'
+    ? state.situationFamiliale
+    : state.projectionSituationFamiliale;
+  const nombreParts = scope === 'revenus-n1'
+    ? state.nombreParts
+    : state.projectionNombreParts;
+  const isole = scope === 'revenus-n1'
+    ? state.isole
+    : state.projectionIsole;
+  const isCouple = situationFamiliale === 'marie';
 
   return {
-    situationFamiliale: state.situationFamiliale,
-    nombreParts: state.nombreParts,
-    isole: state.isole,
+    situationFamiliale,
+    nombreParts,
+    isole,
     declarant1,
     declarant2: isCouple ? declarant2 : undefined,
   };
-}
-
-function buildVisibleSteps(
-  mode: PerMode | null,
-  needsCurrentYearEstimate: boolean,
-): WizardStep[] {
-  if (!mode) {
-    return [1];
-  }
-
-  if (mode === 'declaration-n1') {
-    return [1, 2, 3, 5];
-  }
-
-  return needsCurrentYearEstimate ? [1, 2, 3, 4, 5] : [1, 2, 3, 5];
 }
 
 export interface UsePerPotentielReturn {
@@ -191,11 +206,16 @@ export interface UsePerPotentielReturn {
   setHistoricalBasis: (_basis: PerHistoricalBasis) => void;
   setNeedsCurrentYearEstimate: (_value: boolean) => void;
   updateAvisIr: (_patch: Partial<AvisIrPlafonds>, _decl?: 1 | 2) => void;
-  updateSituation: (_patch: Partial<Pick<PerPotentielState, 'situationFamiliale' | 'isole' | 'mutualisationConjoints'>>) => void;
+  updateSituation: (_patch: PerSituationPatch) => void;
+  updateProjectionSituation: (_patch: PerSituationPatch) => void;
   updateDeclarant: (_scope: PerDeclarantScope, _decl: 1 | 2, _patch: Partial<DeclarantRevenus>) => void;
+  updateDeclarants: (_scope: PerDeclarantScope, _patches: PerDeclarantPatch[]) => void;
   addChild: () => void;
+  addProjectionChild: () => void;
   updateChildMode: (_childId: number, _mode: PerChildDraft['mode']) => void;
+  updateProjectionChildMode: (_childId: number, _mode: PerChildDraft['mode']) => void;
   removeChild: (_childId: number) => void;
+  removeProjectionChild: (_childId: number) => void;
   setVersementEnvisage: (_v: number) => void;
   nextStep: () => void;
   prevStep: () => void;
@@ -266,8 +286,18 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
     persist({ ...state, [key]: { ...current, ...patch, anneeRef: current.anneeRef || avisContext.incomeYear } });
   }, [state, persist, years]);
 
-  const updateSituation = useCallback((patch: Partial<Pick<PerPotentielState, 'situationFamiliale' | 'isole' | 'mutualisationConjoints'>>) => {
+  const updateSituation = useCallback((patch: PerSituationPatch) => {
     persist({ ...state, ...patch });
+  }, [state, persist]);
+
+  const updateProjectionSituation = useCallback((patch: PerSituationPatch) => {
+    persist({
+      ...state,
+      projectionFoyerEdited: true,
+      projectionSituationFamiliale: patch.situationFamiliale ?? state.projectionSituationFamiliale,
+      projectionIsole: patch.isole ?? state.projectionIsole,
+      projectionMutualisationConjoints: patch.mutualisationConjoints ?? state.projectionMutualisationConjoints,
+    });
   }, [state, persist]);
 
   const updateDeclarant = useCallback((scope: PerDeclarantScope, decl: 1 | 2, patch: Partial<DeclarantRevenus>) => {
@@ -277,12 +307,39 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
     persist({ ...state, [key]: { ...state[key], ...patch } });
   }, [state, persist]);
 
+  const updateDeclarants = useCallback((scope: PerDeclarantScope, patches: PerDeclarantPatch[]) => {
+    const next = patches.reduce((acc, { decl, patch }) => {
+      const key: 'revenusN1Declarant1' | 'revenusN1Declarant2' | 'projectionNDeclarant1' | 'projectionNDeclarant2' = scope === 'revenus-n1'
+        ? (decl === 1 ? 'revenusN1Declarant1' : 'revenusN1Declarant2')
+        : (decl === 1 ? 'projectionNDeclarant1' : 'projectionNDeclarant2');
+
+      return {
+        ...acc,
+        [key]: { ...acc[key], ...patch },
+      };
+    }, state);
+
+    persist(next);
+  }, [state, persist]);
+
   const addChild = useCallback(() => {
     const nextChild: PerChildDraft = {
-      id: getNextChildId(state.children),
+      id: getNextPerChildId(state.children),
       mode: 'charge',
     };
     persist({ ...state, children: [...state.children, nextChild] });
+  }, [state, persist]);
+
+  const addProjectionChild = useCallback(() => {
+    const nextChild: PerChildDraft = {
+      id: getNextPerChildId(state.projectionChildren),
+      mode: 'charge',
+    };
+    persist({
+      ...state,
+      projectionFoyerEdited: true,
+      projectionChildren: [...state.projectionChildren, nextChild],
+    });
   }, [state, persist]);
 
   const updateChildMode = useCallback((childId: number, mode: PerChildDraft['mode']) => {
@@ -296,10 +353,30 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
     });
   }, [state, persist]);
 
+  const updateProjectionChildMode = useCallback((childId: number, mode: PerChildDraft['mode']) => {
+    persist({
+      ...state,
+      projectionFoyerEdited: true,
+      projectionChildren: state.projectionChildren.map((child) => (
+        child.id === childId
+          ? { ...child, mode }
+          : child
+      )),
+    });
+  }, [state, persist]);
+
   const removeChild = useCallback((childId: number) => {
     persist({
       ...state,
       children: state.children.filter((child) => child.id !== childId),
+    });
+  }, [state, persist]);
+
+  const removeProjectionChild = useCallback((childId: number) => {
+    persist({
+      ...state,
+      projectionFoyerEdited: true,
+      projectionChildren: state.projectionChildren.filter((child) => child.id !== childId),
     });
   }, [state, persist]);
 
@@ -353,7 +430,10 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
     return true;
   }, [state.step, state.mode, state.historicalBasis]);
 
-  const buildInput = useCallback((useProjection: boolean): PerPotentielInput | null => {
+  const buildInput = useCallback((
+    useProjection: boolean,
+    avisOverride?: Pick<PerPotentielInput, 'avisIr' | 'avisIr2'>,
+  ): PerPotentielInput | null => {
     if (!state.mode) {
       return null;
     }
@@ -376,19 +456,21 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
         useProjection,
         years,
       }),
-      situationFiscale: buildSituationInput(state, 'revenus-n1', isCouple),
+      situationFiscale: buildSituationInput(state, 'revenus-n1'),
       projectionFiscale: useProjection
-        ? buildSituationInput(state, 'projection-n', isCouple)
+        ? buildSituationInput(state, 'projection-n')
         : undefined,
-      avisIr: state.avisIr ?? undefined,
-      avisIr2: state.avisIr2 ?? undefined,
+      avisIr: avisOverride?.avisIr ?? state.avisIr ?? undefined,
+      avisIr2: avisOverride?.avisIr2 ?? state.avisIr2 ?? undefined,
       versementEnvisage: state.versementEnvisage > 0 ? state.versementEnvisage : undefined,
-      mutualisationConjoints: state.mutualisationConjoints,
+      mutualisationConjoints: useProjection
+        ? state.projectionMutualisationConjoints
+        : state.mutualisationConjoints,
       passHistory: fiscalContext.passHistoryByYear,
       taxSettings: fiscalContext._raw_tax,
       psSettings: fiscalContext._raw_ps,
     };
-  }, [state, years, isCouple, fiscalContext]);
+  }, [state, years, fiscalContext]);
 
   const result = useMemo((): PerPotentielResult | null => {
     if (state.step < 3) {
@@ -401,17 +483,43 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
       historicalBasis: state.historicalBasis,
       needsCurrentYearEstimate: state.needsCurrentYearEstimate,
     });
-    const input = buildInput(shouldUseProjection);
-    if (!input) {
-      return null;
-    }
-
     try {
+      let avisOverride: Pick<PerPotentielInput, 'avisIr' | 'avisIr2'> | undefined;
+      if (
+        shouldUseProjection &&
+        state.mode === 'versement-n' &&
+        state.historicalBasis === 'previous-avis-plus-n1'
+      ) {
+        const revenusInput = buildInput(false);
+        if (!revenusInput) {
+          return null;
+        }
+
+        const revenusResult = calculatePerPotentiel(revenusInput);
+        avisOverride = {
+          avisIr: projectionToAvisIrPlafonds(
+            revenusResult.projectionAvisSuivant.declarant1,
+            years.currentIncomeYear,
+          ),
+          avisIr2: revenusResult.projectionAvisSuivant.declarant2
+            ? projectionToAvisIrPlafonds(
+              revenusResult.projectionAvisSuivant.declarant2,
+              years.currentIncomeYear,
+            )
+            : undefined,
+        };
+      }
+
+      const input = buildInput(shouldUseProjection, avisOverride);
+      if (!input) {
+        return null;
+      }
+
       return calculatePerPotentiel(input);
     } catch {
       return null;
     }
-  }, [state.step, state.mode, state.historicalBasis, state.needsCurrentYearEstimate, buildInput]);
+  }, [state.step, state.mode, state.historicalBasis, state.needsCurrentYearEstimate, buildInput, years.currentIncomeYear]);
 
   return {
     state,
@@ -422,10 +530,15 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
     setNeedsCurrentYearEstimate,
     updateAvisIr,
     updateSituation,
+    updateProjectionSituation,
     updateDeclarant,
+    updateDeclarants,
     addChild,
+    addProjectionChild,
     updateChildMode,
+    updateProjectionChildMode,
     removeChild,
+    removeProjectionChild,
     setVersementEnvisage,
     nextStep,
     prevStep,

--- a/src/features/per/hooks/usePerPotentielExportHandlers.ts
+++ b/src/features/per/hooks/usePerPotentielExportHandlers.ts
@@ -4,12 +4,40 @@ import type { ThemeColors } from '../../../settings/theme';
 import type { LogoPlacement } from '../../../pptx/theme/types';
 import { exportPerPotentielExcel, type PerPotentielExcelState } from '../export/perPotentielExcelExport';
 
+type ProjectionAwarePerState = PerPotentielExcelState & Partial<{
+  projectionSituationFamiliale: 'celibataire' | 'marie';
+  projectionNombreParts: number;
+  projectionIsole: boolean;
+  projectionMutualisationConjoints: boolean;
+}>;
+
 interface UsePerPotentielExportHandlersParams {
-  state: PerPotentielExcelState;
+  state: ProjectionAwarePerState;
   result: PerPotentielResult | null;
   pptxColors: ThemeColors;
   cabinetLogo?: string;
   logoPlacement?: LogoPlacement;
+}
+
+function usesProjectionResult(state: ProjectionAwarePerState): boolean {
+  return state.mode === 'versement-n' && (
+    state.historicalBasis === 'current-avis' ||
+    state.needsCurrentYearEstimate
+  );
+}
+
+function getExportState(state: ProjectionAwarePerState): PerPotentielExcelState {
+  if (!usesProjectionResult(state)) {
+    return state;
+  }
+
+  return {
+    ...state,
+    situationFamiliale: state.projectionSituationFamiliale ?? state.situationFamiliale,
+    nombreParts: state.projectionNombreParts ?? state.nombreParts,
+    isole: state.projectionIsole ?? state.isole,
+    mutualisationConjoints: state.projectionMutualisationConjoints ?? state.mutualisationConjoints,
+  };
 }
 
 export function usePerPotentielExportHandlers({
@@ -24,7 +52,7 @@ export function usePerPotentielExportHandlers({
   const exportExcel = useCallback(async () => {
     setExportLoading(true);
     try {
-      await exportPerPotentielExcel(state, result, pptxColors.c1, pptxColors.c7);
+      await exportPerPotentielExcel(getExportState(state), result, pptxColors.c1, pptxColors.c7);
     } catch (errorExport) {
       const err = errorExport instanceof Error ? errorExport : new Error(String(errorExport));
       console.error('[PerPotentielExcel] Export failed', {
@@ -47,16 +75,17 @@ export function usePerPotentielExportHandlers({
     setExportLoading(true);
     try {
       const { exportPerPotentielPptx } = await import('../../../pptx/exports/perExport');
+      const exportState = getExportState(state);
       const dateStr = new Date().toISOString().split('T')[0].replace(/-/g, '');
       await exportPerPotentielPptx(
         {
           mode: state.mode,
           historicalBasis: state.historicalBasis,
           needsCurrentYearEstimate: state.needsCurrentYearEstimate,
-          situationFamiliale: state.situationFamiliale,
-          nombreParts: state.nombreParts,
-          isole: state.isole,
-          mutualisationConjoints: state.mutualisationConjoints,
+          situationFamiliale: exportState.situationFamiliale,
+          nombreParts: exportState.nombreParts,
+          isole: exportState.isole,
+          mutualisationConjoints: exportState.mutualisationConjoints,
           versementEnvisage: state.versementEnvisage,
           result,
         },

--- a/src/features/per/styles/summary.css
+++ b/src/features/per/styles/summary.css
@@ -199,6 +199,12 @@
   color: var(--color-c1);
 }
 
+.per-summary-breakdown-row--muted {
+  justify-content: flex-start;
+  color: var(--color-c9);
+  font-size: 12px;
+}
+
 .per-summary-breakdown-row--total {
   margin-top: 4px;
   padding-top: 12px;

--- a/src/features/per/styles/wizard.css
+++ b/src/features/per/styles/wizard.css
@@ -239,7 +239,7 @@
 .per-potentiel-mini-kpis-row {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
+  gap: 8px;
 }
 
 .per-potentiel-mini-kpi {
@@ -274,6 +274,111 @@
   font-weight: 600;
 }
 
+.per-potentiel-declarant-pair {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(118px, 1fr));
+  gap: 10px;
+}
+
+.per-potentiel-declarant-metric {
+  padding: 11px 12px;
+  border-radius: 10px;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--color-c4) 32%, #FFFFFF), #FFFFFF 78%);
+}
+
+.per-potentiel-declarant-metric__label {
+  display: block;
+  margin-bottom: 5px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-c9) 78%, var(--color-c10));
+}
+
+.per-potentiel-declarant-metric__value {
+  display: block;
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--color-c1);
+  font-variant-numeric: tabular-nums;
+}
+
+.per-potentiel-declarant-pair--compact .per-potentiel-declarant-metric {
+  padding: 9px 11px;
+  background: color-mix(in srgb, var(--color-c7) 82%, #FFFFFF);
+}
+
+.per-potentiel-declarant-pair--compact .per-potentiel-declarant-metric__value {
+  font-size: 17px;
+  font-weight: 600;
+}
+
+.per-potentiel-secondary-metric {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 3px;
+  min-width: 0;
+  padding: 7px 9px;
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--color-c7) 78%, #FFFFFF);
+}
+
+.per-potentiel-secondary-metric__label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-c9);
+}
+
+.per-potentiel-secondary-metric__value {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.1;
+  color: var(--color-c1);
+  font-variant-numeric: tabular-nums;
+}
+
+.per-potentiel-compact-metrics {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+}
+
+.per-potentiel-compact-metric {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+}
+
+.per-potentiel-compact-metric dt,
+.per-potentiel-compact-metric dd {
+  margin: 0;
+}
+
+.per-potentiel-compact-metric dt {
+  min-width: 0;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-c9);
+}
+
+.per-potentiel-compact-metric dd {
+  flex-shrink: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-c1);
+  font-variant-numeric: tabular-nums;
+}
+
 .per-potentiel-context-section {
   display: grid;
   gap: 12px;
@@ -286,7 +391,7 @@
 
 .per-potentiel-preview-columns {
   display: grid;
-  gap: 16px;
+  gap: 14px;
 }
 
 .per-potentiel-preview-columns.is-couple {
@@ -295,12 +400,12 @@
 
 .per-potentiel-preview-column {
   display: grid;
-  gap: 10px;
+  gap: 8px;
 }
 
 .per-potentiel-preview-columns.is-couple .per-potentiel-preview-column + .per-potentiel-preview-column {
-  padding-left: 16px;
-  border-left: 1px solid var(--color-c8);
+  padding-left: 14px;
+  border-left: 1px solid color-mix(in srgb, var(--color-c8) 60%, transparent);
 }
 
 .per-potentiel-preview-column__title {

--- a/src/features/per/utils/perCalculationYear.test.ts
+++ b/src/features/per/utils/perCalculationYear.test.ts
@@ -12,7 +12,7 @@ const years: PerWorkflowYears = {
 };
 
 describe('resolvePerCalculationYear', () => {
-  it('utilise le barème IR 2025 pour la tab Revenus 2025', () => {
+  it('utilise le barème courant 2026 sur la tab Revenus 2025', () => {
     expect(resolvePerCalculationYear({
       step: 3,
       mode: 'versement-n',
@@ -21,11 +21,11 @@ describe('resolvePerCalculationYear', () => {
       years,
     })).toEqual({
       anneeRef: 2025,
-      yearKey: 'previous',
+      yearKey: 'current',
     });
   });
 
-  it('utilise le barème courant pour la projection 2026', () => {
+  it('utilise le même barème courant pour la projection 2026 avec le PASS 2026', () => {
     expect(resolvePerCalculationYear({
       step: 4,
       mode: 'versement-n',

--- a/src/features/per/utils/perCalculationYear.ts
+++ b/src/features/per/utils/perCalculationYear.ts
@@ -18,7 +18,7 @@ export interface PerCalculationYear {
 }
 
 function resolveYearKey(anneeRef: number, years: PerWorkflowYears): PerYearKey {
-  if (anneeRef === years.previousTaxYear) {
+  if (anneeRef === years.previousIncomeYear) {
     return 'previous';
   }
 

--- a/src/features/per/utils/perFoyerState.ts
+++ b/src/features/per/utils/perFoyerState.ts
@@ -1,0 +1,56 @@
+import { derivePerNombreParts, type PerChildDraft } from './perParts';
+
+export type PerSituationFamiliale = 'celibataire' | 'marie';
+
+export interface PerNormalizedFoyer {
+  situationFamiliale: PerSituationFamiliale;
+  nombreParts: number;
+  isole: boolean;
+  children: PerChildDraft[];
+  mutualisationConjoints: boolean;
+}
+
+export function normalizePerChildren(children: PerChildDraft[] | null | undefined): PerChildDraft[] {
+  return Array.isArray(children)
+    ? children
+      .filter((child): child is PerChildDraft => Boolean(child) && (child.mode === 'charge' || child.mode === 'shared'))
+      .map((child, index) => ({
+        id: Number.isFinite(child.id) ? child.id : index + 1,
+        mode: child.mode,
+      }))
+    : [];
+}
+
+export function normalizePerFoyer({
+  situationFamiliale,
+  isole,
+  children,
+  mutualisationConjoints,
+}: {
+  situationFamiliale: PerSituationFamiliale;
+  isole: boolean;
+  children: PerChildDraft[] | null | undefined;
+  mutualisationConjoints: boolean;
+}): PerNormalizedFoyer {
+  const normalizedChildren = normalizePerChildren(children);
+  const normalizedIsole = situationFamiliale === 'marie' ? false : isole;
+  const normalizedMutualisation = situationFamiliale === 'marie'
+    ? mutualisationConjoints
+    : false;
+
+  return {
+    situationFamiliale,
+    isole: normalizedIsole,
+    children: normalizedChildren,
+    mutualisationConjoints: normalizedMutualisation,
+    nombreParts: derivePerNombreParts({
+      situationFamiliale,
+      isole: normalizedIsole,
+      children: normalizedChildren,
+    }),
+  };
+}
+
+export function getNextPerChildId(children: PerChildDraft[]): number {
+  return children.reduce((maxId, child) => Math.max(maxId, child.id), 0) + 1;
+}

--- a/src/features/per/utils/perSyntheticAvis.test.ts
+++ b/src/features/per/utils/perSyntheticAvis.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { projectionToAvisIrPlafonds } from './perSyntheticAvis';
+
+describe('projectionToAvisIrPlafonds', () => {
+  it('transforme le prochain avis projeté en avis IR utilisable pour l’année suivante', () => {
+    expect(projectionToAvisIrPlafonds({
+      nonUtiliseN2: 1000,
+      nonUtiliseN1: 2000,
+      nonUtiliseN: 3000,
+      plafondCalculeN: 4000,
+      plafondTotal: 10_000,
+    }, 2025)).toEqual({
+      nonUtiliseAnnee1: 1000,
+      nonUtiliseAnnee2: 2000,
+      nonUtiliseAnnee3: 3000,
+      plafondCalcule: 4000,
+      anneeRef: 2025,
+    });
+  });
+});

--- a/src/features/per/utils/perSyntheticAvis.ts
+++ b/src/features/per/utils/perSyntheticAvis.ts
@@ -1,0 +1,14 @@
+import type { AvisIrPlafonds, PerProjectionAvisDetail } from '../../../engine/per';
+
+export function projectionToAvisIrPlafonds(
+  projection: PerProjectionAvisDetail,
+  incomeYear: number,
+): AvisIrPlafonds {
+  return {
+    nonUtiliseAnnee1: projection.nonUtiliseN2,
+    nonUtiliseAnnee2: projection.nonUtiliseN1,
+    nonUtiliseAnnee3: projection.nonUtiliseN,
+    plafondCalcule: projection.plafondCalculeN,
+    anneeRef: incomeYear,
+  };
+}

--- a/src/features/per/utils/perVisibleSteps.test.ts
+++ b/src/features/per/utils/perVisibleSteps.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { buildVisibleSteps } from './perVisibleSteps';
+
+describe('buildVisibleSteps', () => {
+  it('supprime l’étape Synthèse du parcours déclaration 2042', () => {
+    expect(buildVisibleSteps('declaration-n1', false)).toEqual([1, 2, 3]);
+  });
+
+  it('supprime l’étape Synthèse du parcours versement sans projection', () => {
+    expect(buildVisibleSteps('versement-n', false)).toEqual([1, 2, 3]);
+  });
+
+  it('garde l’estimation 2026 uniquement quand la projection est activée', () => {
+    expect(buildVisibleSteps('versement-n', true)).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/src/features/per/utils/perVisibleSteps.ts
+++ b/src/features/per/utils/perVisibleSteps.ts
@@ -1,0 +1,17 @@
+export type PerVisibleStep = 1 | 2 | 3 | 4 | 5;
+export type PerVisibleMode = 'versement-n' | 'declaration-n1' | null;
+
+export function buildVisibleSteps(
+  mode: PerVisibleMode,
+  needsCurrentYearEstimate: boolean,
+): PerVisibleStep[] {
+  if (!mode) {
+    return [1];
+  }
+
+  if (mode === 'declaration-n1') {
+    return [1, 2, 3];
+  }
+
+  return needsCurrentYearEstimate ? [1, 2, 3, 4] : [1, 2, 3];
+}


### PR DESCRIPTION
## Description
Refonte ciblée du parcours `/sim/per/potentiel` : sidebar plus lisible, statut TNS simplifié, enchaînement 2025/2026 corrigé et suppression de l’étape UI `Synthèse`.

## Changements
- Enrichit le calcul piloté par le hook PER : situation familiale de projection, avis IR synthétique issu des plafonds 2025 recalculés, sélection du millésime IR/PASS selon l’étape.
- Revoit la sidebar `Potentiel` / `Synthèse déclaration` : KPI principal, détails compacts, titres contextualisés et Madelin disponible par déclarant.
- Remplace les toggles `D1 TNS` / `D2 TNS` par un toggle foyer atomique et garde les champs TNS éditables quand le statut est actif.
- Supprime l’étape visible `Synthèse`, renomme l’onglet déclaratif en `Revenus 2025` et active les exports dès qu’un résultat est disponible.
- Allège la modale Madelin quand aucune base TNS n’est saisie.

## Fonctionnalités
- `Revenus 2025` utilise le barème courant des settings pour les revenus 2025 tout en conservant le PASS 2025.
- `Estimation 2026` peut porter une situation familiale propre et utilise les plafonds recalculés depuis 2025 dans le parcours `Avis IR 2025 disponible`.
- Quand la projection annuelle n’est pas activée, l’étape `Estimation 2026` n’est plus proposée.

## Tests effectués
- [x] `npm run lint` passe
- [x] `npm run typecheck` passe
- [x] `npm test` passe
- [x] `npm run build` passe
- [x] `npm run check` passe (si utilisé comme agrégat)
- [x] `npm run check:pre-merge` passe

## Notes
Le moteur fiscal existant reste la source des calculs ; cette PR réorganise surtout le pilotage du parcours et l’affichage. L’export Excel conserve sa feuille interne `Synthèse`, seule la tab UI du wizard est supprimée.

## Checklist
- [x] Pas de push direct sur `main` 
- [x] Pas de fichiers temporaires ajoutés à la racine
- [x] Documentation mise à jour si nécessaire