### PR TITLE
feat(per): ajuster le workflow des tabs selon le mode

### DIFF
--- a/src/features/per/components/potentiel/PerPotentielSimulator.test.tsx
+++ b/src/features/per/components/potentiel/PerPotentielSimulator.test.tsx
@@ -72,11 +72,17 @@ vi.mock('./steps/AvisIrStep', () => ({
 vi.mock('./steps/SituationFiscaleStep', () => ({
   default: ({
     showFoyerCard,
+    showIncomeCard,
     situationFamiliale,
   }: {
     showFoyerCard: boolean;
+    showIncomeCard: boolean;
     situationFamiliale: 'celibataire' | 'marie';
-  }) => <div>Situation step {showFoyerCard ? 'foyer visible' : 'foyer masqué'} {situationFamiliale}</div>,
+  }) => (
+    <div>
+      Situation step {showFoyerCard ? 'foyer visible' : 'foyer masqué'} {showIncomeCard ? 'revenus visibles' : 'revenus masqués'} {situationFamiliale}
+    </div>
+  ),
 }));
 
 vi.mock('./steps/SynthesePotentielStep', () => ({
@@ -182,7 +188,7 @@ function makeHookReturn(step: number) {
         },
       }
       : null,
-    visibleSteps: [1, 2, 3],
+    visibleSteps: [1, 2, 3, 4],
     setMode: vi.fn(),
     setHistoricalBasis: vi.fn(),
     setNeedsCurrentYearEstimate: vi.fn(),
@@ -244,7 +250,7 @@ describe('PerPotentielSimulator', () => {
         historicalBasis: 'current-avis',
         needsCurrentYearEstimate: true,
       },
-      visibleSteps: [1, 2, 3, 4],
+      visibleSteps: [1, 2, 3],
     });
 
     const html = renderToStaticMarkup(<PerPotentielSimulator />);
@@ -252,7 +258,7 @@ describe('PerPotentielSimulator', () => {
     expect(html).toContain('Sidebar contexte 11000 / 7000');
   });
 
-  it('affiche une situation familiale distincte sur l’estimation 2026', () => {
+  it('affiche les revenus sur Versement N quand la projection est activée', () => {
     mockUsePerPotentiel.mockReturnValue({
       ...makeHookReturn(4),
       state: {
@@ -269,7 +275,40 @@ describe('PerPotentielSimulator', () => {
 
     const html = renderToStaticMarkup(<PerPotentielSimulator />);
 
-    expect(html).toContain('Situation step foyer visible marie');
+    expect(html).toContain('Situation step foyer visible revenus visibles marie');
+  });
+
+  it('affiche un Versement N simplifié avec avis IR 2026 sans projection', () => {
+    mockUsePerPotentiel.mockReturnValue({
+      ...makeHookReturn(3),
+      state: {
+        ...makeHookState(3),
+        historicalBasis: 'current-avis',
+        needsCurrentYearEstimate: false,
+      },
+      visibleSteps: [1, 2, 3],
+    });
+
+    const html = renderToStaticMarkup(<PerPotentielSimulator />);
+
+    expect(html).toContain('Versement N');
+    expect(html).toContain('Situation step foyer masqué revenus masqués celibataire');
+  });
+
+  it('masque les revenus sur Versement N quand la projection est inactive', () => {
+    mockUsePerPotentiel.mockReturnValue({
+      ...makeHookReturn(4),
+      state: {
+        ...makeHookState(4),
+        needsCurrentYearEstimate: false,
+        projectionSituationFamiliale: 'marie',
+      },
+      visibleSteps: [1, 2, 3, 4],
+    });
+
+    const html = renderToStaticMarkup(<PerPotentielSimulator />);
+
+    expect(html).toContain('Situation step foyer masqué revenus masqués marie');
   });
 
   it('renomme la tab déclaration en Revenus 2025 et masque la synthèse', () => {

--- a/src/features/per/components/potentiel/PerPotentielSimulator.tsx
+++ b/src/features/per/components/potentiel/PerPotentielSimulator.tsx
@@ -71,8 +71,8 @@ function getStepMeta(
       }
       if (basis === 'current-avis') {
         return {
-          shortLabel: 'Versements N',
-          title: `Versements ${years.currentTaxYear} et estimation optionnelle`,
+          shortLabel: 'Versement N',
+          title: `Versements ${years.currentTaxYear}`,
         };
       }
       return {
@@ -81,8 +81,8 @@ function getStepMeta(
       };
     case 4:
       return {
-        shortLabel: `Estimation ${years.currentTaxYear}`,
-        title: `Estimation des revenus ${years.currentTaxYear}`,
+        shortLabel: 'Versement N',
+        title: `Versements ${years.currentTaxYear}`,
       };
     case 5:
     default:
@@ -198,9 +198,11 @@ export default function PerPotentielSimulator(): React.ReactElement {
   const usesProjectionFoyer = state.mode === 'versement-n' && (
     state.historicalBasis === 'current-avis'
       ? state.step >= 3
-      : state.needsCurrentYearEstimate && state.step >= 4
+      : state.step >= 4
   );
-  const activeIsCouple = usesProjectionFoyer ? projectionIsCouple : revenusIsCouple;
+  const activeIsCouple = usesProjectionFoyer
+    ? projectionIsCouple || (!state.needsCurrentYearEstimate && Boolean(state.avisIr2))
+    : revenusIsCouple;
   const abat10CfgRoot = fiscalContext._raw_tax?.incomeTax?.abat10 ?? {};
   const abat10SalCfgCurrent: PerAbattementConfig = abat10CfgRoot.current ?? {};
   const abat10RetCfgCurrent: PerAbattementConfig = abat10CfgRoot.retireesCurrent ?? {};
@@ -209,9 +211,16 @@ export default function PerPotentielSimulator(): React.ReactElement {
       state.mode === 'declaration-n1'
       || (state.mode === 'versement-n' && state.historicalBasis === 'previous-avis-plus-n1')
     );
+  const isVersementNStep = state.mode === 'versement-n' && (
+    (state.historicalBasis === 'current-avis' && state.step === 3)
+    || (state.historicalBasis === 'previous-avis-plus-n1' && state.step === 4)
+  );
+  const showProjectionDetailInputs = state.needsCurrentYearEstimate;
   const fiscalPreviewTitle = isRevenusStep
     ? `Synthèse déclaration IR ${years.currentTaxYear}`
-    : `Estimation fiscale ${years.currentTaxYear}`;
+    : (isVersementNStep && !showProjectionDetailInputs
+      ? `Contrôle versement ${years.currentTaxYear}`
+      : `Projection IR ${years.currentTaxYear + 1}`);
   const projectionPreviewTitle = 'Plafonds projetés';
 
   const avisBasis = state.mode === 'declaration-n1'
@@ -308,6 +317,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   variant="revenus-n1"
                   yearLabel={`${years.currentIncomeYear}`}
                   showFoyerCard
+                  showIncomeCard
                   situationFamiliale={state.situationFamiliale}
                   isole={state.isole}
                   children={state.children}
@@ -334,6 +344,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   variant="revenus-n1"
                   yearLabel={`${years.currentIncomeYear}`}
                   showFoyerCard
+                  showIncomeCard
                   situationFamiliale={state.situationFamiliale}
                   isole={state.isole}
                   children={state.children}
@@ -359,7 +370,8 @@ export default function PerPotentielSimulator(): React.ReactElement {
                 <SituationFiscaleStep
                   variant="versements-n"
                   yearLabel={`${years.currentTaxYear}`}
-                  showFoyerCard
+                  showFoyerCard={showProjectionDetailInputs}
+                  showIncomeCard={showProjectionDetailInputs}
                   situationFamiliale={state.projectionSituationFamiliale}
                   isole={state.projectionIsole}
                   children={state.projectionChildren}
@@ -381,11 +393,12 @@ export default function PerPotentielSimulator(): React.ReactElement {
                 />
               )}
 
-              {state.step === 4 && (
+              {state.step === 4 && state.mode === 'versement-n' && state.historicalBasis === 'previous-avis-plus-n1' && (
                 <SituationFiscaleStep
-                  variant="projection-n"
+                  variant="versements-n"
                   yearLabel={`${years.currentTaxYear}`}
-                  showFoyerCard
+                  showFoyerCard={showProjectionDetailInputs}
+                  showIncomeCard={showProjectionDetailInputs}
                   situationFamiliale={state.projectionSituationFamiliale}
                   isole={state.projectionIsole}
                   children={state.projectionChildren}

--- a/src/features/per/components/potentiel/steps/ModeStep.tsx
+++ b/src/features/per/components/potentiel/steps/ModeStep.tsx
@@ -139,8 +139,8 @@ export default function ModeStep({
                 {needsCurrentYearEstimate && (
                   <p className="per-mode-toggle-hint">
                     L&apos;estimation {years.currentTaxYear} est activée. Vous renseignerez les revenus
-                    et versements de l&apos;année en cours (Madelin, PERCO, PEROB, art. 83) à l&apos;étape
-                    suivante.
+                    et versements de l&apos;année en cours (Madelin, PERCO, PEROB, art. 83) dans la tab
+                    Versement N.
                   </p>
                 )}
               </div>

--- a/src/features/per/components/potentiel/steps/SituationFiscaleStep.test.tsx
+++ b/src/features/per/components/potentiel/steps/SituationFiscaleStep.test.tsx
@@ -25,6 +25,7 @@ const baseDeclarant = {
 const baseProps = {
   variant: 'revenus-n1' as const,
   yearLabel: '2025',
+  showIncomeCard: true,
   situationFamiliale: 'celibataire' as const,
   isole: true,
   children: [{ id: 1, mode: 'charge' as const }],
@@ -97,6 +98,20 @@ describe('SituationFiscaleStep', () => {
     expect(html).toContain('Pensions, retraites et rentes');
     expect(html).toContain('Abattement 10 % pensions (foyer)');
     expect(html).toContain('Revenus fonciers nets');
+  });
+
+  it('peut masquer les revenus imposables sans masquer les versements retraite', () => {
+    const html = renderToStaticMarkup(
+      <SituationFiscaleStep
+        showFoyerCard={false}
+        {...baseProps}
+        showIncomeCard={false}
+      />,
+    );
+
+    expect(html).not.toContain('Revenus imposables');
+    expect(html).toContain('Versements retraite');
+    expect(html).toContain('PER 163 quatervicies');
   });
 
   it('uses the updated contribution notes and info button', () => {

--- a/src/features/per/components/potentiel/steps/SituationFiscaleStep.tsx
+++ b/src/features/per/components/potentiel/steps/SituationFiscaleStep.tsx
@@ -22,6 +22,7 @@ interface SituationFiscaleStepProps {
   variant: FiscalStepVariant;
   yearLabel: string;
   showFoyerCard: boolean;
+  showIncomeCard: boolean;
   situationFamiliale: 'celibataire' | 'marie';
   isole: boolean;
   children: PerChildDraft[];
@@ -62,6 +63,7 @@ export default function SituationFiscaleStep({
   variant,
   yearLabel,
   showFoyerCard,
+  showIncomeCard,
   situationFamiliale,
   isole,
   children,
@@ -182,17 +184,19 @@ export default function SituationFiscaleStep({
         </div>
       )}
 
-      <PerIncomeTable
-        isCouple={isCouple}
-        declarant1={declarant1}
-        declarant2={declarant2}
-        incomeFilters={incomeFilters}
-        abat10SalCfg={abat10SalCfg}
-        abat10RetCfg={abat10RetCfg}
-        onToggleIncomeFilter={onToggleIncomeFilter}
-        onUpdateDeclarant={onUpdateDeclarant}
-        onUpdateDeclarants={onUpdateDeclarants}
-      />
+      {showIncomeCard && (
+        <PerIncomeTable
+          isCouple={isCouple}
+          declarant1={declarant1}
+          declarant2={declarant2}
+          incomeFilters={incomeFilters}
+          abat10SalCfg={abat10SalCfg}
+          abat10RetCfg={abat10RetCfg}
+          onToggleIncomeFilter={onToggleIncomeFilter}
+          onUpdateDeclarant={onUpdateDeclarant}
+          onUpdateDeclarants={onUpdateDeclarants}
+        />
+      )}
 
       <div className="premium-card premium-card--guide sim-card--guide per-contribution-card">
         <SectionHeader

--- a/src/features/per/hooks/usePerPotentiel.ts
+++ b/src/features/per/hooks/usePerPotentiel.ts
@@ -80,7 +80,7 @@ const EMPTY_DECLARANT: DeclarantRevenus = {
 };
 
 function normalizeState(state: PerPotentielState): PerPotentielState {
-  const visibleSteps = buildVisibleSteps(state.mode, state.needsCurrentYearEstimate);
+  const visibleSteps = buildVisibleSteps(state.mode, state.historicalBasis, state.needsCurrentYearEstimate);
   const fallbackStep = visibleSteps[visibleSteps.length - 1] ?? 1;
   const step = visibleSteps.includes(state.step) ? state.step : fallbackStep;
   const foyer = normalizePerFoyer({
@@ -175,6 +175,7 @@ function saveSession(state: PerPotentielState): void {
 function buildSituationInput(
   state: PerPotentielState,
   scope: PerDeclarantScope,
+  forceCouple = false,
 ): PerPotentielInput['situationFiscale'] {
   const declarant1 = scope === 'revenus-n1' ? state.revenusN1Declarant1 : state.projectionNDeclarant1;
   const declarant2 = scope === 'revenus-n1' ? state.revenusN1Declarant2 : state.projectionNDeclarant2;
@@ -187,7 +188,7 @@ function buildSituationInput(
   const isole = scope === 'revenus-n1'
     ? state.isole
     : state.projectionIsole;
-  const isCouple = situationFamiliale === 'marie';
+  const isCouple = situationFamiliale === 'marie' || forceCouple;
 
   return {
     situationFamiliale,
@@ -229,8 +230,8 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
   const [state, setState] = useState<PerPotentielState>(() => loadSession() ?? makeDefaultState());
   const years = useMemo(() => getPerWorkflowYears(fiscalContext), [fiscalContext]);
   const visibleSteps = useMemo(
-    () => buildVisibleSteps(state.mode, state.needsCurrentYearEstimate),
-    [state.mode, state.needsCurrentYearEstimate],
+    () => buildVisibleSteps(state.mode, state.historicalBasis, state.needsCurrentYearEstimate),
+    [state.mode, state.historicalBasis, state.needsCurrentYearEstimate],
   );
 
   const persist = useCallback((next: PerPotentielState) => {
@@ -446,6 +447,10 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
       return null;
     }
 
+    const forceProjectionCouple = useProjection
+      && !state.needsCurrentYearEstimate
+      && Boolean(avisOverride?.avisIr2 ?? state.avisIr2);
+
     return {
       mode: state.mode,
       historicalBasis,
@@ -458,7 +463,7 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
       }),
       situationFiscale: buildSituationInput(state, 'revenus-n1'),
       projectionFiscale: useProjection
-        ? buildSituationInput(state, 'projection-n')
+        ? buildSituationInput(state, 'projection-n', forceProjectionCouple)
         : undefined,
       avisIr: avisOverride?.avisIr ?? state.avisIr ?? undefined,
       avisIr2: avisOverride?.avisIr2 ?? state.avisIr2 ?? undefined,

--- a/src/features/per/hooks/usePerPotentielExportHandlers.ts
+++ b/src/features/per/hooks/usePerPotentielExportHandlers.ts
@@ -5,6 +5,7 @@ import type { LogoPlacement } from '../../../pptx/theme/types';
 import { exportPerPotentielExcel, type PerPotentielExcelState } from '../export/perPotentielExcelExport';
 
 type ProjectionAwarePerState = PerPotentielExcelState & Partial<{
+  step: number;
   projectionSituationFamiliale: 'celibataire' | 'marie';
   projectionNombreParts: number;
   projectionIsole: boolean;
@@ -22,7 +23,8 @@ interface UsePerPotentielExportHandlersParams {
 function usesProjectionResult(state: ProjectionAwarePerState): boolean {
   return state.mode === 'versement-n' && (
     state.historicalBasis === 'current-avis' ||
-    state.needsCurrentYearEstimate
+    state.needsCurrentYearEstimate ||
+    (state.historicalBasis === 'previous-avis-plus-n1' && state.step === 4)
   );
 }
 

--- a/src/features/per/utils/perProjectionScope.test.ts
+++ b/src/features/per/utils/perProjectionScope.test.ts
@@ -11,12 +11,12 @@ describe('shouldUseProjectionForCalculation', () => {
     })).toBe(false);
   });
 
-  it('bascule sur la projection à partir de la step 4 quand l’estimation N est activée', () => {
+  it('bascule sur les versements N à partir de la step 4 après reconstitution 2025', () => {
     expect(shouldUseProjectionForCalculation({
       step: 4,
       mode: 'versement-n',
       historicalBasis: 'previous-avis-plus-n1',
-      needsCurrentYearEstimate: true,
+      needsCurrentYearEstimate: false,
     })).toBe(true);
   });
 

--- a/src/features/per/utils/perProjectionScope.ts
+++ b/src/features/per/utils/perProjectionScope.ts
@@ -14,7 +14,6 @@ export function shouldUseProjectionForCalculation({
   step,
   mode,
   historicalBasis,
-  needsCurrentYearEstimate,
 }: PerProjectionScopeParams): boolean {
   if (mode !== 'versement-n' || historicalBasis === null) {
     return false;
@@ -24,5 +23,5 @@ export function shouldUseProjectionForCalculation({
     return step >= 3;
   }
 
-  return needsCurrentYearEstimate && step >= 4;
+  return step >= 4;
 }

--- a/src/features/per/utils/perVisibleSteps.test.ts
+++ b/src/features/per/utils/perVisibleSteps.test.ts
@@ -3,14 +3,19 @@ import { buildVisibleSteps } from './perVisibleSteps';
 
 describe('buildVisibleSteps', () => {
   it('supprime l’étape Synthèse du parcours déclaration 2042', () => {
-    expect(buildVisibleSteps('declaration-n1', false)).toEqual([1, 2, 3]);
+    expect(buildVisibleSteps('declaration-n1', 'previous-avis-plus-n1', false)).toEqual([1, 2, 3]);
   });
 
-  it('supprime l’étape Synthèse du parcours versement sans projection', () => {
-    expect(buildVisibleSteps('versement-n', false)).toEqual([1, 2, 3]);
+  it('ajoute Versement N après les revenus 2025 quand on part de l’avis IR 2025', () => {
+    expect(buildVisibleSteps('versement-n', 'previous-avis-plus-n1', false)).toEqual([1, 2, 3, 4]);
   });
 
-  it('garde l’estimation 2026 uniquement quand la projection est activée', () => {
-    expect(buildVisibleSteps('versement-n', true)).toEqual([1, 2, 3, 4]);
+  it('garde un parcours court quand on part de l’avis IR 2026', () => {
+    expect(buildVisibleSteps('versement-n', 'current-avis', false)).toEqual([1, 2, 3]);
+  });
+
+  it('ne crée pas de tab supplémentaire quand la projection est activée', () => {
+    expect(buildVisibleSteps('versement-n', 'current-avis', true)).toEqual([1, 2, 3]);
+    expect(buildVisibleSteps('versement-n', 'previous-avis-plus-n1', true)).toEqual([1, 2, 3, 4]);
   });
 });

--- a/src/features/per/utils/perVisibleSteps.ts
+++ b/src/features/per/utils/perVisibleSteps.ts
@@ -1,9 +1,12 @@
+import type { PerHistoricalBasis } from '../../../engine/per';
+
 export type PerVisibleStep = 1 | 2 | 3 | 4 | 5;
 export type PerVisibleMode = 'versement-n' | 'declaration-n1' | null;
 
 export function buildVisibleSteps(
   mode: PerVisibleMode,
-  needsCurrentYearEstimate: boolean,
+  historicalBasis: PerHistoricalBasis | null,
+  _needsCurrentYearEstimate: boolean,
 ): PerVisibleStep[] {
   if (!mode) {
     return [1];
@@ -13,5 +16,13 @@ export function buildVisibleSteps(
     return [1, 2, 3];
   }
 
-  return needsCurrentYearEstimate ? [1, 2, 3, 4] : [1, 2, 3];
+  if (historicalBasis === 'previous-avis-plus-n1') {
+    return [1, 2, 3, 4];
+  }
+
+  if (historicalBasis === 'current-avis') {
+    return [1, 2, 3];
+  }
+
+  return [1];
 }


### PR DESCRIPTION
## Description
Ajuste l’enchaînement des tabs de `/sim/per/potentiel` pour qu’il soit cohérent selon le mode choisi et la base documentaire (Avis IR 2025 vs Avis IR 2026).
Masque les blocs non pertinents sur la tab `Versement N` quand la projection de l’année en cours n’est pas activée.

## Changements
- [src/features/per/utils/perVisibleSteps.ts](C:/Users/flore/Documents/SER1/src/features/per/utils/perVisibleSteps.ts) : étapes visibles désormais dépendantes de `historicalBasis`.
- [src/features/per/utils/perProjectionScope.ts](C:/Users/flore/Documents/SER1/src/features/per/utils/perProjectionScope.ts) : bascule de calcul projection alignée sur le nouveau flux (`step >= 4` pour `previous-avis-plus-n1`).
- [src/features/per/hooks/usePerPotentiel.ts](C:/Users/flore/Documents/SER1/src/features/per/hooks/usePerPotentiel.ts) : intégration de `historicalBasis` dans les étapes et ajustement `projectionFiscale` pour le cas couple sans projection détaillée.
- [src/features/per/components/potentiel/PerPotentielSimulator.tsx](C:/Users/flore/Documents/SER1/src/features/per/components/potentiel/PerPotentielSimulator.tsx) : libellés/tab `Versement N`, affichage conditionnel des blocs et titres de sidebar contextualisés.
- [src/features/per/components/potentiel/steps/SituationFiscaleStep.tsx](C:/Users/flore/Documents/SER1/src/features/per/components/potentiel/steps/SituationFiscaleStep.tsx) : ajout `showIncomeCard` pour masquer/afficher `Revenus imposables` indépendamment de `Situation familiale`.
- [src/features/per/hooks/usePerPotentielExportHandlers.ts](C:/Users/flore/Documents/SER1/src/features/per/hooks/usePerPotentielExportHandlers.ts) : export aligné avec le contexte `Versement N` (step 4 sans projection détaillée).
- Tests mis à jour sur `perVisibleSteps`, `perProjectionScope`, `PerPotentielSimulator`, `SituationFiscaleStep`.

## Fonctionnalités
- Parcours `Contrôle du potentiel avant versement` + `Avis IR 2025` : `Mode -> Avis IR -> Revenus 2025 -> Versement N`.
- Parcours `Contrôle du potentiel avant versement` + `Avis IR 2026` : `Mode -> Avis IR -> Versement N`.
- Sur `Versement N` :
  - projection OFF => affichage uniquement de `Versements retraite`.
  - projection ON => affichage de `Situation familiale` + `Revenus imposables` + `Versements retraite`.

## Tests effectués
- [x] `npm run lint` passe
- [x] `npm run typecheck` passe
- [x] `npm test` passe
- [x] `npm run build` passe
- [x] `npm run check` passe (si utilisé comme agrégat)

## Notes
Le diff est volontairement ciblé sur le workflow de navigation et le rendu conditionnel des cartes de saisie. Le moteur fiscal est conservé, avec un ajustement de scope pour que le calcul en `Versement N` reste cohérent même sans projection détaillée.

## Checklist
- [x] Pas de push direct sur `main` 
- [x] Pas de fichiers temporaires ajoutés à la racine
- [x] Documentation mise à jour si nécessaire