### PR TITLE
Refonte PPTX PER potentiel

### DIFF
--- a/src/features/per/__tests__/perPotentielExport.test.ts
+++ b/src/features/per/__tests__/perPotentielExport.test.ts
@@ -65,23 +65,21 @@ describe('PER Potentiel PPTX Export', () => {
       {
         ...state,
         result,
+        anneeRef: 2025,
+        passReference: DEFAULT_PASS_HISTORY[2025] ?? 0,
+        irScale: DEFAULT_TAX_SETTINGS.incomeTax.scaleCurrent,
+        irScaleLabel: DEFAULT_TAX_SETTINGS.incomeTax.currentYearLabel,
       },
       THEME_COLORS,
     );
 
     expect(spec.cover.type).toBe('cover');
-    expect(spec.cover.title).toContain('PER');
+    expect(spec.cover.title).toBe('Étude — Potentiel épargne retraite');
     expect(spec.slides.some((slide) => slide.type === 'chapter')).toBe(true);
-    expect(
-      spec.slides.some(
-        (slide) => slide.type === 'content' && 'title' in slide && slide.title === 'Cases 2042 simulees',
-      ),
-    ).toBe(true);
-    expect(
-      spec.slides.some(
-        (slide) => slide.type === 'content' && 'title' in slide && slide.title === 'Projection du prochain avis IR',
-      ),
-    ).toBe(true);
+    expect(spec.slides.some((slide) => slide.type === 'per-fiscal-snapshot')).toBe(true);
+    expect(spec.slides.some((slide) => slide.type === 'per-plafond-3col')).toBe(true);
+    expect(spec.slides.some((slide) => slide.type === 'per-projection-table')).toBe(true);
+    expect(spec.slides.some((slide) => slide.type === 'content')).toBe(false);
   });
 });
 

--- a/src/features/per/components/potentiel/PerPotentielContextSidebar.test.tsx
+++ b/src/features/per/components/potentiel/PerPotentielContextSidebar.test.tsx
@@ -144,6 +144,7 @@ describe('PerPotentielContextSidebar', () => {
         step={3}
         isCouple
         showRevenusPreview
+        showAdjustedPotentiel
         fiscalPreviewTitle="Synthèse déclaration IR 2026"
         projectionPreviewTitle="Plafonds projetés"
         parcoursPills={[{ label: 'Avis IR 2025', on: true }]}
@@ -180,6 +181,7 @@ describe('PerPotentielContextSidebar', () => {
         step={3}
         isCouple
         showRevenusPreview={false}
+        showAdjustedPotentiel={false}
         fiscalPreviewTitle="Estimation fiscale 2026"
         projectionPreviewTitle="Plafonds projetés"
         parcoursPills={[{ label: 'Avis IR 2025', on: true }]}
@@ -193,5 +195,28 @@ describe('PerPotentielContextSidebar', () => {
     expect(html).toContain('Plafonds projetés');
     expect(html).not.toContain('Aperçu en direct');
     expect(html).toContain(fmtCurrency(11111));
+  });
+
+  it('uses the remaining 163 quatervicies on the Versement N step', () => {
+    const html = renderToStaticMarkup(
+      <PerPotentielContextSidebar
+        step={4}
+        isCouple
+        showRevenusPreview={false}
+        showAdjustedPotentiel
+        fiscalPreviewTitle="Contrôle versement 2026"
+        projectionPreviewTitle="Plafonds projetés"
+        parcoursPills={[{ label: 'Avis IR 2025', on: true }]}
+        totalAvisIrD1={11111}
+        totalAvisIrD2={7777}
+        result={result}
+      />,
+    );
+
+    expect(html).toContain('163 quatervicies disponible après saisie');
+    expect(html).toContain(fmtCurrency(6543));
+    expect(html).toContain(fmtCurrency(3210));
+    expect(html).not.toContain(fmtCurrency(11111));
+    expect(html).not.toContain("163 quatervicies issu de l'avis IR");
   });
 });

--- a/src/features/per/components/potentiel/PerPotentielContextSidebar.tsx
+++ b/src/features/per/components/potentiel/PerPotentielContextSidebar.tsx
@@ -6,6 +6,7 @@ interface PerPotentielContextSidebarProps {
   step: WizardStep;
   isCouple: boolean;
   showRevenusPreview: boolean;
+  showAdjustedPotentiel: boolean;
   fiscalPreviewTitle: string;
   projectionPreviewTitle: string;
   parcoursPills: Array<{ label: string; on: boolean }>;
@@ -123,6 +124,7 @@ export function PerPotentielContextSidebar({
   step,
   isCouple,
   showRevenusPreview,
+  showAdjustedPotentiel,
   fiscalPreviewTitle,
   projectionPreviewTitle,
   parcoursPills,
@@ -130,15 +132,15 @@ export function PerPotentielContextSidebar({
   totalAvisIrD2,
   result,
 }: PerPotentielContextSidebarProps): React.ReactElement {
-  const showPotentielAvis = step <= 3;
+  const showPotentielAvis = step <= 3 || showAdjustedPotentiel;
   const showLivePreview = Boolean(result && step !== 5);
-  const potentielD1 = showRevenusPreview && result
+  const potentielD1 = showAdjustedPotentiel && result
     ? result.deductionFlow163Q.declarant1.disponibleRestant
     : totalAvisIrD1;
-  const potentielD2 = showRevenusPreview && result
+  const potentielD2 = showAdjustedPotentiel && result
     ? result.deductionFlow163Q.declarant2?.disponibleRestant ?? totalAvisIrD2
     : totalAvisIrD2;
-  const potentielLabel = showRevenusPreview
+  const potentielLabel = showAdjustedPotentiel
     ? '163 quatervicies disponible après saisie'
     : "163 quatervicies issu de l'avis IR";
   const potentielItems = [

--- a/src/features/per/components/potentiel/PerPotentielSimulator.tsx
+++ b/src/features/per/components/potentiel/PerPotentielSimulator.tsx
@@ -137,6 +137,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
     pptxColors,
     cabinetLogo,
     logoPlacement,
+    fiscalContext,
   });
 
   if (loading) {
@@ -432,6 +433,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
             step={state.step}
             isCouple={activeIsCouple}
             showRevenusPreview={isRevenusStep}
+            showAdjustedPotentiel={isRevenusStep || isVersementNStep}
             fiscalPreviewTitle={fiscalPreviewTitle}
             projectionPreviewTitle={projectionPreviewTitle}
             parcoursPills={parcoursPills}

--- a/src/features/per/hooks/usePerPotentielExportHandlers.ts
+++ b/src/features/per/hooks/usePerPotentielExportHandlers.ts
@@ -2,7 +2,10 @@ import { useCallback, useState } from 'react';
 import type { PerPotentielResult } from '../../../engine/per';
 import type { ThemeColors } from '../../../settings/theme';
 import type { LogoPlacement } from '../../../pptx/theme/types';
+import type { FiscalContext } from '../../../hooks/useFiscalContext';
 import { exportPerPotentielExcel, type PerPotentielExcelState } from '../export/perPotentielExcelExport';
+import { getPerWorkflowYears } from '../utils/perWorkflowYears';
+import { shouldUseProjectionForCalculation, type PerProjectionScopeStep } from '../utils/perProjectionScope';
 
 type ProjectionAwarePerState = PerPotentielExcelState & Partial<{
   step: number;
@@ -18,14 +21,16 @@ interface UsePerPotentielExportHandlersParams {
   pptxColors: ThemeColors;
   cabinetLogo?: string;
   logoPlacement?: LogoPlacement;
+  fiscalContext: FiscalContext;
 }
 
 function usesProjectionResult(state: ProjectionAwarePerState): boolean {
-  return state.mode === 'versement-n' && (
-    state.historicalBasis === 'current-avis' ||
-    state.needsCurrentYearEstimate ||
-    (state.historicalBasis === 'previous-avis-plus-n1' && state.step === 4)
-  );
+  return shouldUseProjectionForCalculation({
+    step: (state.step ?? 5) as PerProjectionScopeStep,
+    mode: state.mode ?? null,
+    historicalBasis: state.historicalBasis,
+    needsCurrentYearEstimate: state.needsCurrentYearEstimate,
+  });
 }
 
 function getExportState(state: ProjectionAwarePerState): PerPotentielExcelState {
@@ -42,12 +47,25 @@ function getExportState(state: ProjectionAwarePerState): PerPotentielExcelState 
   };
 }
 
+function resolvePassReference(passHistory: Record<number, number>, anneeRef: number): number {
+  const direct = passHistory[anneeRef];
+  if (direct != null) return direct;
+
+  const fallbackYear = Object.keys(passHistory)
+    .map(Number)
+    .filter((year) => Number.isFinite(year) && year <= anneeRef)
+    .sort((left, right) => right - left)[0];
+
+  return fallbackYear != null ? passHistory[fallbackYear] ?? 0 : 0;
+}
+
 export function usePerPotentielExportHandlers({
   state,
   result,
   pptxColors,
   cabinetLogo,
   logoPlacement,
+  fiscalContext,
 }: UsePerPotentielExportHandlersParams) {
   const [exportLoading, setExportLoading] = useState(false);
 
@@ -62,7 +80,7 @@ export function usePerPotentielExportHandlers({
         message: err.message,
         stack: err.stack,
       });
-      alert('Impossible de generer le fichier Excel.');
+      alert('Impossible de générer le fichier Excel.');
     } finally {
       setExportLoading(false);
     }
@@ -70,7 +88,7 @@ export function usePerPotentielExportHandlers({
 
   const exportPowerPoint = useCallback(async () => {
     if (!result || !state.mode) {
-      alert('Les resultats ne sont pas disponibles.');
+      alert('Les résultats ne sont pas disponibles.');
       return;
     }
 
@@ -78,6 +96,10 @@ export function usePerPotentielExportHandlers({
     try {
       const { exportPerPotentielPptx } = await import('../../../pptx/exports/perExport');
       const exportState = getExportState(state);
+      const years = getPerWorkflowYears(fiscalContext);
+      const exportUsesProjection = usesProjectionResult(state);
+      const anneeRef = exportUsesProjection ? years.currentTaxYear : years.currentIncomeYear;
+      const usesPreviousScale = anneeRef === years.previousIncomeYear;
       const dateStr = new Date().toISOString().split('T')[0].replace(/-/g, '');
       await exportPerPotentielPptx(
         {
@@ -90,6 +112,10 @@ export function usePerPotentielExportHandlers({
           mutualisationConjoints: exportState.mutualisationConjoints,
           versementEnvisage: state.versementEnvisage,
           result,
+          anneeRef,
+          passReference: resolvePassReference(fiscalContext.passHistoryByYear, anneeRef),
+          irScale: usesPreviousScale ? fiscalContext.irScalePrevious : fiscalContext.irScaleCurrent,
+          irScaleLabel: usesPreviousScale ? fiscalContext.irPreviousYearLabel : fiscalContext.irCurrentYearLabel,
         },
         pptxColors,
         {
@@ -105,11 +131,11 @@ export function usePerPotentielExportHandlers({
         message: err.message,
         stack: err.stack,
       });
-      alert('Impossible de generer le fichier PowerPoint.');
+      alert('Impossible de générer le fichier PowerPoint.');
     } finally {
       setExportLoading(false);
     }
-  }, [state, result, pptxColors, cabinetLogo, logoPlacement]);
+  }, [state, result, pptxColors, cabinetLogo, logoPlacement, fiscalContext]);
 
   return { exportExcel, exportPowerPoint, exportLoading };
 }

--- a/src/pptx/export/exportStudyDeck.ts
+++ b/src/pptx/export/exportStudyDeck.ts
@@ -23,6 +23,9 @@ import type {
   PlacementDetailSlideSpec,
   PlacementHypothesesSlideSpec,
   PlacementProjectionSlideSpec,
+  PerFiscalSnapshotSlideSpec,
+  PerPlafond3ColSlideSpec,
+  PerProjectionTableSlideSpec,
 } from '../theme/types';
 import { SLIDE_SIZE } from '../designSystem/serenity';
 import { getPptxThemeFromUiSettings } from '../theme/getPptxThemeFromUiSettings';
@@ -41,6 +44,9 @@ import { buildPlacementSynthesis } from '../slides/buildPlacementSynthesis';
 import { buildPlacementDetail } from '../slides/buildPlacementDetail';
 import { buildPlacementHypotheses } from '../slides/buildPlacementHypotheses';
 import { buildPlacementProjection } from '../slides/buildPlacementProjection';
+import { buildPerFiscalSnapshot } from '../slides/buildPerFiscalSnapshot';
+import { buildPerPlafond3Col } from '../slides/buildPerPlafond3Col';
+import { buildPerProjectionTable } from '../slides/buildPerProjectionTable';
 import { injectThemeColors } from '../theme/themeBuilder';
 import { defineSlideMasters } from '../template/loadBaseTemplate';
 import { createTrackedObjectURL } from '../../utils/export/createTrackedObjectURL';
@@ -362,6 +368,15 @@ export async function exportStudyDeck(
     } else if (slideSpec.type === 'placement-projection') {
       // Placement Projection slide — paginated year-by-year table
       buildPlacementProjection(pptx, slideSpec as PlacementProjectionSlideSpec, ctx, slideIndex);
+    } else if (slideSpec.type === 'per-fiscal-snapshot') {
+      // PER — situation fiscale avec échelle TMI
+      buildPerFiscalSnapshot(pptx, slideSpec as PerFiscalSnapshotSlideSpec, ctx, slideIndex);
+    } else if (slideSpec.type === 'per-plafond-3col') {
+      // PER — plafonds en trois colonnes
+      buildPerPlafond3Col(pptx, slideSpec as PerPlafond3ColSlideSpec, ctx, slideIndex);
+    } else if (slideSpec.type === 'per-projection-table') {
+      // PER — déclaration 2042 et prochain avis IR
+      buildPerProjectionTable(pptx, slideSpec as PerProjectionTableSlideSpec, ctx, slideIndex);
     }
     
     slideIndex++;

--- a/src/pptx/presets/perDeckBuilder.ts
+++ b/src/pptx/presets/perDeckBuilder.ts
@@ -1,11 +1,21 @@
 import type {
-  StudyDeckSpec,
   ChapterSlideSpec,
   ContentSlideSpec,
   LogoPlacement,
+  PerFiscalBracket,
+  PerFiscalSnapshotSlideSpec,
+  PerPlafond3ColSlideSpec,
+  PerProjectionTableSlideSpec,
+  StudyDeckSpec,
 } from '../theme/types';
 import { pickChapterImage } from '../designSystem/serenity';
 import type { PerPotentielResult } from '../../engine/per';
+
+type IrScaleRow = {
+  from: number;
+  to: number | null;
+  rate: number;
+};
 
 export interface PerDeckData {
   mode: 'versement-n' | 'declaration-n1';
@@ -18,6 +28,10 @@ export interface PerDeckData {
   versementEnvisage: number;
   result: PerPotentielResult;
   clientName?: string;
+  anneeRef?: number;
+  passReference?: number;
+  irScale?: IrScaleRow[];
+  irScaleLabel?: string;
 }
 
 export interface PerUiSettingsForPptx {
@@ -37,172 +51,238 @@ export interface PerAdvisorInfo {
   name?: string;
 }
 
-const LEGAL_TEXT = `Document etabli a titre strictement indicatif et depourvu de valeur contractuelle. Il a ete elabore sur la base des dispositions legales et reglementaires en vigueur a la date de sa remise, lesquelles sont susceptibles d evoluer.
+const LEGAL_TEXT = `Document établi à titre strictement indicatif et dépourvu de valeur contractuelle. Il a été élaboré sur la base des dispositions légales et réglementaires en vigueur à la date de sa remise, lesquelles sont susceptibles d'évoluer.
 
-Les informations qu il contient sont strictement confidentielles et destinees exclusivement aux personnes expressement autorisees.
+Les informations qu'il contient sont strictement confidentielles et destinées exclusivement aux personnes expressément autorisées.
 
-Toute reproduction, representation, diffusion ou rediffusion, totale ou partielle, sur quelque support ou par quelque procede que ce soit, ainsi que toute vente, revente, retransmission ou mise a disposition de tiers, est strictement encadree. Le non-respect de ces dispositions est susceptible de constituer une contrefacon engageant la responsabilite civile et penale de son auteur, conformement aux articles L335-1 a L335-10 du Code de la propriete intellectuelle.`;
+Toute reproduction, représentation, diffusion ou rediffusion, totale ou partielle, sur quelque support ou par quelque procédé que ce soit, ainsi que toute vente, revente, retransmission ou mise à disposition de tiers, est strictement encadrée. Le non-respect de ces dispositions est susceptible de constituer une contrefaçon engageant la responsabilité civile et pénale de son auteur, conformément aux articles L335-1 à L335-10 du Code de la propriété intellectuelle.`;
 
 function euro(value: number): string {
   return new Intl.NumberFormat('fr-FR', {
     style: 'currency',
     currency: 'EUR',
     maximumFractionDigits: 0,
-  }).format(value);
-}
-
-function pct(value: number): string {
-  return `${(value * 100).toFixed(1)} %`;
-}
-
-function yesNo(value: boolean): string {
-  return value ? 'Oui' : 'Non';
+  }).format(Math.round(value || 0));
 }
 
 function basisLabel(basis: PerDeckData['historicalBasis']): string {
-  if (basis === 'current-avis') return 'Avis IR courant déjà disponible';
-  if (basis === 'previous-avis-plus-n1') return 'Avis IR précédent + reconstitution N-1';
+  if (basis === 'current-avis') return 'Avis IR courant disponible';
+  if (basis === 'previous-avis-plus-n1') return 'Avis IR précédent et reconstitution';
   return 'Base documentaire à confirmer';
 }
 
 function modeTitle(mode: PerDeckData['mode']): string {
   return mode === 'declaration-n1'
-    ? 'Declaration 2042 epargne retraite'
-    : 'Controle du potentiel epargne retraite';
+    ? 'Déclaration 2042 épargne retraite'
+    : 'Contrôle du potentiel épargne retraite';
+}
+
+function currentDateLong(): string {
+  return new Intl.DateTimeFormat('fr-FR', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  }).format(new Date());
+}
+
+function advisorMeta(advisor?: PerAdvisorInfo): string {
+  if (advisor?.name) {
+    return `${advisor.name}\nConseiller en gestion de patrimoine`;
+  }
+  return 'Conseiller en gestion de patrimoine';
 }
 
 function buildObjectifsBody(data: PerDeckData): string {
-  return [
-    `- Parcours retenu : ${modeTitle(data.mode)}.`,
-    `- Base documentaire : ${basisLabel(data.historicalBasis)}.`,
-    `- Projection N active : ${yesNo(data.needsCurrentYearEstimate)}.`,
-    '- Le parcours reprend la logique pedagogique du classeur Excel 2025.',
-    '- Les calculs d IR sont arbitres par le moteur fiscal du repo, pas par une simplification locale.',
-    '- L export ci-dessous synthetise les plafonds personnels, la mutualisation et les cases 2042 utiles.',
-  ].join('\n');
+  if (data.mode === 'declaration-n1') {
+    return "Vous souhaitez préparer les cases 2042 « charges déductibles » à partir des versements d'épargne retraite réalisés et visualiser l'impact sur le prochain avis d'impôt.";
+  }
+
+  if (data.historicalBasis === 'current-avis') {
+    return "Vous partez de l'avis IR disponible pour vérifier le potentiel d'épargne retraite mobilisable avant versement et, le cas échéant, projeter l'année en cours.";
+  }
+
+  return "Vous partez de l'avis IR précédent, reconstituez les revenus et versements de l'année, puis estimez le potentiel disponible pour arbitrer un versement.";
 }
 
-function buildSituationBody(data: PerDeckData): string {
-  const sf = data.result.situationFiscale;
-  const lines = [
-    `- Situation familiale : ${data.situationFamiliale === 'marie' ? 'Marie / Pacse' : 'Celibataire / Veuf / Divorce'}.`,
-    `- Nombre de parts retenu : ${data.nombreParts}.`,
-    `- Parent isole : ${yesNo(data.isole)}.`,
-    `- Revenu imposable declarant 1 : ${euro(sf.revenuImposableD1)}.`,
-  ];
+function buildFiscalBrackets(data: PerDeckData): {
+  brackets: PerFiscalBracket[];
+  activeThreshold: number | null;
+} {
+  const activeRate = Math.round((data.result.situationFiscale.tmi || 0) * 100);
+  const brackets = (data.irScale ?? []).map((row) => ({
+    label: `${row.rate.toLocaleString('fr-FR')} %`,
+    rate: row.rate,
+    threshold: row.from,
+  }));
+  const active = brackets.find((row) => Math.round(row.rate) === activeRate);
 
-  if (sf.revenuImposableD2 > 0) {
-    lines.push(`- Revenu imposable declarant 2 : ${euro(sf.revenuImposableD2)}.`);
-  }
-
-  lines.push(`- Revenu fiscal de reference estime : ${euro(sf.revenuFiscalRef)}.`);
-  lines.push(`- TMI : ${pct(sf.tmi)}.`);
-  lines.push(`- IR estime : ${euro(sf.irEstime)}.`);
-
-  if (sf.decote > 0) {
-    lines.push(`- Decote : ${euro(sf.decote)}.`);
-  }
-  if (sf.cehr > 0) {
-    lines.push(`- CEHR : ${euro(sf.cehr)}.`);
-  }
-  if (sf.montantDansLaTMI > 0) {
-    lines.push(`- Marge restante dans la TMI : ${euro(sf.montantDansLaTMI)}.`);
-  }
-
-  return lines.join('\n');
+  return {
+    brackets,
+    activeThreshold: active?.threshold ?? null,
+  };
 }
 
-function buildPlafond163QBody(data: PerDeckData): string {
-  const d1 = data.result.plafond163Q.declarant1;
-  const d2 = data.result.plafond163Q.declarant2;
-  const flow1 = data.result.deductionFlow163Q.declarant1;
-  const flow2 = data.result.deductionFlow163Q.declarant2;
-  const lines = [
-    `- Declarant 1 : potentiel issu de l'avis ${euro(d1.totalDisponible)}, cotisations retenues ${euro(flow1.cotisationsRetenuesIr)}, disponible restant ${euro(flow1.disponibleRestant)}.`,
-  ];
+function buildFiscalSnapshotSlide(data: PerDeckData): PerFiscalSnapshotSlideSpec {
+  const { result } = data;
+  const { brackets, activeThreshold } = buildFiscalBrackets(data);
 
-  if (d2 && flow2) {
-    lines.push(`- Declarant 2 : potentiel issu de l'avis ${euro(d2.totalDisponible)}, cotisations retenues ${euro(flow2.cotisationsRetenuesIr)}, disponible restant ${euro(flow2.disponibleRestant)}.`);
-    lines.push(`- Mutualisation des plafonds (6QR) : ${yesNo(data.mutualisationConjoints)}.`);
-  }
-
-  if (data.result.warnings.length > 0) {
-    lines.push(`- Alertes moteur : ${data.result.warnings.map((warning) => warning.message).join(' | ')}.`);
-  }
-
-  return lines.join('\n');
+  return {
+    type: 'per-fiscal-snapshot',
+    title: 'Estimation de la situation fiscale',
+    subtitle: data.irScaleLabel || 'Barème IR issu des paramètres',
+    tmiRate: result.situationFiscale.tmi,
+    activeThreshold,
+    irEstime: result.situationFiscale.irEstime,
+    revenuImposableFoyer: result.situationFiscale.revenuFiscalRef,
+    partsNb: data.nombreParts,
+    montantDansLaTMI: result.situationFiscale.montantDansLaTMI,
+    brackets,
+  };
 }
 
-function buildMadelinBody(data: PerDeckData): string {
-  const d1 = data.result.plafondMadelin?.declarant1;
-  const d2 = data.result.plafondMadelin?.declarant2;
-  if (!d1) {
-    return '- Aucun plafond Madelin a restituer.';
-  }
-
-  const lines = [
-    `- Declarant 1 : assiette de versement ${euro(d1.assietteVersement)}, enveloppe 15 % ${euro(d1.enveloppe15Versement)}, enveloppe 10 % ${euro(d1.enveloppe10)}, reintegration ${euro(d1.surplusAReintegrer)}.`,
-  ];
-
-  if (d2) {
-    lines.push(`- Declarant 2 : assiette de versement ${euro(d2.assietteVersement)}, enveloppe 15 % ${euro(d2.enveloppe15Versement)}, enveloppe 10 % ${euro(d2.enveloppe10)}, reintegration ${euro(d2.surplusAReintegrer)}.`);
-  }
-
-  return lines.join('\n');
-}
-
-function buildDeclarationBody(data: PerDeckData): string {
-  const boxes = data.result.declaration2042;
-  const lines = [
-    `- 6NS : ${euro(boxes.case6NS)}.`,
-    `- 6RS : ${euro(boxes.case6RS)}.`,
-    `- 6QS : ${euro(boxes.case6QS)} (flux Art. 83 / PERCO / Madelin retraite).`,
-    `- 6OS : ${euro(boxes.case6OS)}.`,
-  ];
-
-  if (typeof boxes.case6NT === 'number') {
-    lines.push(`- 6NT : ${euro(boxes.case6NT)}.`);
-  }
-  if (typeof boxes.case6RT === 'number') {
-    lines.push(`- 6RT : ${euro(boxes.case6RT)}.`);
-  }
-  if (typeof boxes.case6QT === 'number') {
-    lines.push(`- 6QT : ${euro(boxes.case6QT)}.`);
-  }
-  if (typeof boxes.case6OT === 'number') {
-    lines.push(`- 6OT : ${euro(boxes.case6OT)}.`);
-  }
-
-  lines.push(`- 6QR : ${yesNo(boxes.case6QR)}.`);
-  return lines.join('\n');
-}
-
-function buildProjectionBody(data: PerDeckData): string {
-  const d1 = data.result.projectionAvisSuivant.declarant1;
-  const d2 = data.result.projectionAvisSuivant.declarant2;
-  const lines = [
-    `- Declarant 1 : reliquats ${euro(d1.nonUtiliseN2)} / ${euro(d1.nonUtiliseN1)} / ${euro(d1.nonUtiliseN)}, plafond calcule ${euro(d1.plafondCalculeN)}, total ${euro(d1.plafondTotal)}.`,
-  ];
-
-  if (d2) {
-    lines.push(`- Declarant 2 : reliquats ${euro(d2.nonUtiliseN2)} / ${euro(d2.nonUtiliseN1)} / ${euro(d2.nonUtiliseN)}, plafond calcule ${euro(d2.plafondCalculeN)}, total ${euro(d2.plafondTotal)}.`);
-  }
-
-  return lines.join('\n');
-}
-
-function buildSimulationBody(data: PerDeckData): string {
-  if (!data.result.simulation) {
-    return '- Aucun versement simule dans cette exportation.';
+function passIntro(data: PerDeckData): string {
+  if (!data.passReference || data.passReference <= 0) {
+    return "Le potentiel personnel correspond au plafond 163 quatervicies disponible après prise en compte des versements et de la mutualisation éventuelle.";
   }
 
   return [
-    `- Versement envisage : ${euro(data.result.simulation.versementEnvisage)}.`,
-    `- Versement deductible retenu : ${euro(data.result.simulation.versementDeductible)}.`,
-    `- Economie IR annuelle estimee : ${euro(data.result.simulation.economieIRAnnuelle)}.`,
-    `- Cout net apres fiscalite : ${euro(data.result.simulation.coutNetApresFiscalite)}.`,
-    `- Plafond restant apres versement : ${euro(data.result.simulation.plafondRestantApres)}.`,
-  ].join('\n');
+    'Le potentiel personnel correspond au plafond 163 quatervicies, calculé sur les revenus professionnels et les reliquats reportables.',
+    `Pour l'année de référence, le PASS retenu est ${euro(data.passReference)}.`,
+  ].join(' ');
+}
+
+function buildPlafond163QSlide(data: PerDeckData): PerPlafond3ColSlideSpec {
+  const { result } = data;
+  const flow1 = result.deductionFlow163Q.declarant1;
+  const flow2 = result.deductionFlow163Q.declarant2;
+  const year = data.anneeRef ? String(data.anneeRef) : 'N';
+
+  return {
+    type: 'per-plafond-3col',
+    title: `Plafonds épargne retraite 163Q pour ${year}`,
+    subtitle: 'Disponible, versements retenus et solde',
+    variant: '163q',
+    intro: passIntro(data),
+    isCouple: !!flow2,
+    columns: [
+      {
+        heading: 'Disponible après mutualisation',
+        iconName: 'bank',
+        values: {
+          declarant1: flow1.plafondApresMutualisation,
+          declarant2: flow2?.plafondApresMutualisation,
+        },
+      },
+      {
+        heading: 'Versements retenus pour l’IR',
+        iconName: 'pen',
+        values: {
+          declarant1: flow1.cotisationsRetenuesIr,
+          declarant2: flow2?.cotisationsRetenuesIr,
+        },
+      },
+      {
+        heading: 'Disponible restant',
+        iconName: 'gauge',
+        values: {
+          declarant1: flow1.disponibleRestant,
+          declarant2: flow2?.disponibleRestant,
+        },
+      },
+    ],
+    note: result.declaration2042.case6QR
+      ? 'Mutualisation des plafonds activée : les disponibles du conjoint peuvent absorber un dépassement.'
+      : undefined,
+  };
+}
+
+function madelinAvailable(detail?: { enveloppe15Versement: number; enveloppe10: number }): number {
+  return (detail?.enveloppe15Versement ?? 0) + (detail?.enveloppe10 ?? 0);
+}
+
+function buildMadelinSlide(data: PerDeckData): PerPlafond3ColSlideSpec | null {
+  const madelin = data.result.plafondMadelin;
+  if (!data.result.estTNS || !madelin) {
+    return null;
+  }
+
+  const d1 = madelin.declarant1;
+  const d2 = madelin.declarant2;
+  const surplus = (d1?.surplusAReintegrer ?? 0) + (d2?.surplusAReintegrer ?? 0);
+  const year = data.anneeRef ? String(data.anneeRef) : 'N';
+
+  return {
+    type: 'per-plafond-3col',
+    title: `Plafonds Madelin 154 bis pour ${year}`,
+    subtitle: 'Assiette, enveloppe et solde TNS',
+    variant: 'madelin',
+    intro: "Le potentiel Madelin 154 bis est réservé aux travailleurs non-salariés. Il distingue l'assiette de versement, l'enveloppe ouverte et le disponible restant après consommation.",
+    isCouple: !!d2,
+    columns: [
+      {
+        heading: 'Assiette de versement',
+        iconName: 'calculator',
+        values: {
+          declarant1: d1.assietteVersement,
+          declarant2: d2?.assietteVersement,
+        },
+      },
+      {
+        heading: 'Enveloppe disponible',
+        iconName: 'bank',
+        values: {
+          declarant1: madelinAvailable(d1),
+          declarant2: madelinAvailable(d2),
+        },
+        caption: '15 % + 10 % selon la situation TNS',
+      },
+      {
+        heading: 'Disponible restant',
+        iconName: 'gauge',
+        values: {
+          declarant1: d1.disponibleRestant,
+          declarant2: d2?.disponibleRestant,
+        },
+      },
+    ],
+    note: surplus > 0 ? `Surplus à réintégrer en base imposable : ${euro(surplus)}.` : undefined,
+  };
+}
+
+function buildProjectionSlide(data: PerDeckData): PerProjectionTableSlideSpec {
+  const { declaration2042, projectionAvisSuivant, simulation } = data.result;
+  const isCouple = !!projectionAvisSuivant.declarant2;
+  const projection1 = projectionAvisSuivant.declarant1;
+  const projection2 = projectionAvisSuivant.declarant2;
+
+  return {
+    type: 'per-projection-table',
+    title: "Déclaration 2042 et prochain avis d'impôt",
+    subtitle: 'Synthèse des reports et reliquats projetés',
+    isCouple,
+    declarationRows: [
+      { label: '6NS / 6NT — PER 163 quatervicies', declarant1: declaration2042.case6NS, declarant2: declaration2042.case6NT },
+      { label: '6RS / 6RT — PERP et assimilés', declarant1: declaration2042.case6RS, declarant2: declaration2042.case6RT },
+      { label: '6OS / 6OT — PER 154 bis', declarant1: declaration2042.case6OS, declarant2: declaration2042.case6OT },
+      { label: '6QS / 6QT — Madelin, PERCO, Art. 83', declarant1: declaration2042.case6QS, declarant2: declaration2042.case6QT },
+      { label: '6QR — Mutualisation conjoint', declarant1: declaration2042.case6QR },
+    ],
+    avisRows: [
+      { label: 'Reliquat N-2', declarant1: projection1.nonUtiliseN2, declarant2: projection2?.nonUtiliseN2 },
+      { label: 'Reliquat N-1', declarant1: projection1.nonUtiliseN1, declarant2: projection2?.nonUtiliseN1 },
+      { label: 'Reliquat N', declarant1: projection1.nonUtiliseN, declarant2: projection2?.nonUtiliseN },
+      { label: 'Plafond calculé', declarant1: projection1.plafondCalculeN, declarant2: projection2?.plafondCalculeN },
+      { label: 'Total projeté', declarant1: projection1.plafondTotal, declarant2: projection2?.plafondTotal },
+    ],
+    simulationRows: simulation
+      ? [
+        { label: 'Versement envisagé', value: simulation.versementEnvisage },
+        { label: 'Versement déductible retenu', value: simulation.versementDeductible },
+        { label: "Économie d'IR estimée", value: simulation.economieIRAnnuelle },
+        { label: 'Coût net après fiscalité', value: simulation.coutNetApresFiscalite },
+      ]
+      : undefined,
+  };
 }
 
 export function buildPerStudyDeck(
@@ -212,81 +292,44 @@ export function buildPerStudyDeck(
   logoPlacement?: LogoPlacement,
   advisor?: PerAdvisorInfo,
 ): StudyDeckSpec {
-  const dateStr = new Date().toLocaleDateString('fr-FR', {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-  });
+  const fiscalSlide = buildFiscalSnapshotSlide(data);
+  const plafondSlide = buildPlafond163QSlide(data);
+  const madelinSlide = buildMadelinSlide(data);
+  const projectionSlide = buildProjectionSlide(data);
 
-  const slides: Array<ChapterSlideSpec | ContentSlideSpec> = [
+  const slides: Array<
+    | ChapterSlideSpec
+    | ContentSlideSpec
+    | PerFiscalSnapshotSlideSpec
+    | PerPlafond3ColSlideSpec
+    | PerProjectionTableSlideSpec
+  > = [
     {
       type: 'chapter',
-      title: 'Objectifs et contexte',
-      subtitle: modeTitle(data.mode),
+      title: 'Objectifs & contexte',
+      subtitle: `${modeTitle(data.mode)} — ${basisLabel(data.historicalBasis)}`,
       body: buildObjectifsBody(data),
       chapterImageIndex: pickChapterImage('per', 0),
     },
-    {
-      type: 'content',
-      title: 'Situation fiscale',
-      subtitle: 'Lecture du foyer retenu',
-      body: buildSituationBody(data),
-    },
-    {
-      type: 'content',
-      title: 'Plafonds disponibles',
-      subtitle: '163 quatervicies et mutualisation',
-      body: buildPlafond163QBody(data),
-    },
+    fiscalSlide,
+    plafondSlide,
   ];
 
-  if (data.result.estTNS && data.result.plafondMadelin) {
-    slides.push({
-      type: 'content',
-      title: 'Plafond Madelin 154 bis',
-      subtitle: 'Lecture TNS',
-      body: buildMadelinBody(data),
-    });
+  if (madelinSlide) {
+    slides.push(madelinSlide);
   }
 
-  slides.push({
-    type: 'chapter',
-    title: 'Synthese declarative',
-    subtitle: 'Cases 2042 et restitution',
-    body: 'Cette partie reprend les cases 2042 simulees et la logique de mutualisation retenue dans le parcours.',
-    chapterImageIndex: pickChapterImage('per', 1),
-  });
-  slides.push({
-    type: 'content',
-    title: 'Cases 2042 simulees',
-    subtitle: 'Versements et mutualisation',
-    body: buildDeclarationBody(data),
-  });
-  slides.push({
-    type: 'content',
-    title: 'Projection du prochain avis IR',
-    subtitle: 'Reliquats et plafond calculé',
-    body: buildProjectionBody(data),
-  });
-
-  if (data.mode === 'versement-n' && data.result.simulation) {
-    slides.push({
-      type: 'content',
-      title: 'Impact du versement',
-      subtitle: 'Simulation fiscale immediate',
-      body: buildSimulationBody(data),
-    });
-  }
+  slides.push(projectionSlide);
 
   return {
     cover: {
       type: 'cover',
-      title: 'Simulation PER - Potentiel',
+      title: 'Étude — Potentiel épargne retraite',
       subtitle: data.clientName || modeTitle(data.mode),
       logoUrl,
       logoPlacement,
-      leftMeta: dateStr,
-      rightMeta: advisor?.name || 'SER1',
+      leftMeta: currentDateLong(),
+      rightMeta: advisorMeta(advisor),
     },
     slides,
     end: {

--- a/src/pptx/slides/buildCover.ts
+++ b/src/pptx/slides/buildCover.ts
@@ -143,12 +143,9 @@ export function buildCover(
     valign: 'middle',
   });
   
-  // Advisor info: 2 lines, font size 12, aligned RIGHT
-  // Line 1: "Conseiller en gestion de patrimoine"
-  // Line 2: "Bureau de [location]"
-  const advisorLine1 = 'Conseiller en gestion de patrimoine';
-  const advisorLine2 = 'Bureau de ';
-  const advisorText = `${advisorLine1}\n${advisorLine2}`;
+  // Advisor info: uses the explicit right meta when provided, otherwise keeps
+  // the historical default used by existing exports.
+  const advisorText = spec.rightMeta || ctx.coverRightMeta || 'Conseiller en gestion de patrimoine\nBureau de ';
   
   addTextBox(slide, advisorText, COORDS_COVER.metaRight, {
     fontSize: 12,

--- a/src/pptx/slides/buildPerFiscalSnapshot.ts
+++ b/src/pptx/slides/buildPerFiscalSnapshot.ts
@@ -1,0 +1,204 @@
+import type PptxGenJS from 'pptxgenjs';
+import type { ExportContext, PerFiscalSnapshotSlideSpec, PptxThemeRoles } from '../theme/types';
+import {
+  RADIUS,
+  SLIDE_SIZE,
+  addCardPanelWithShadow,
+  addFooter,
+  addHeader,
+  addTextFr,
+  roleColor,
+} from '../designSystem/serenity';
+import { MASTER_NAMES } from '../template/loadBaseTemplate';
+
+const GEO = {
+  marginX: 0.92,
+  barY: 2.05,
+  barH: 0.46,
+  markerY: 2.66,
+  tableX: 1.55,
+  tableY: 3.18,
+  tableW: 10.23,
+  tableH: 2.62,
+} as const;
+
+function euro(value: number): string {
+  return new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  }).format(Math.round(value || 0));
+}
+
+function pct(value: number): string {
+  return `${(value * 100).toFixed(1).replace('.', ',')} %`;
+}
+
+function clean(color: string): string {
+  return color.replace('#', '');
+}
+
+function bracketColor(index: number, theme: PptxThemeRoles): string {
+  const palette = [
+    theme.colors.color4,
+    theme.colors.color8,
+    theme.colors.color7,
+    theme.colors.color6,
+    theme.colors.color5,
+  ];
+  return clean(palette[Math.min(index, palette.length - 1)] ?? palette[palette.length - 1]);
+}
+
+function formatThreshold(value: number | null): string {
+  return value == null ? 'Dernière tranche' : `À partir de ${euro(value)}`;
+}
+
+function drawTmiScale(
+  slide: PptxGenJS.Slide,
+  spec: PerFiscalSnapshotSlideSpec,
+  theme: PptxThemeRoles,
+): void {
+  const brackets = spec.brackets.length > 0
+    ? spec.brackets
+    : [{ label: pct(spec.tmiRate), rate: spec.tmiRate * 100, threshold: spec.activeThreshold }];
+  const activeRate = Math.round(spec.tmiRate * 100);
+  const barW = SLIDE_SIZE.width - GEO.marginX * 2;
+  const segmentW = barW / brackets.length;
+  let activeCenterX = GEO.marginX + segmentW / 2;
+
+  brackets.forEach((bracket, index) => {
+    const x = GEO.marginX + index * segmentW;
+    const isActive = Math.round(bracket.rate) === activeRate;
+    const color = bracketColor(index, theme);
+    if (isActive) {
+      activeCenterX = x + segmentW / 2;
+    }
+
+    slide.addShape('roundRect', {
+      x,
+      y: GEO.barY,
+      w: segmentW - 0.03,
+      h: GEO.barH,
+      rectRadius: RADIUS.panel,
+      fill: { color },
+      line: {
+        color: isActive ? clean(theme.bgMain) : color,
+        width: isActive ? 1.7 : 0,
+      },
+    });
+
+    addTextFr(slide, bracket.label, {
+      x,
+      y: GEO.barY,
+      w: segmentW - 0.03,
+      h: GEO.barH,
+      fontSize: 12,
+      bold: isActive,
+      color: isActive ? clean(theme.textOnMain) : clean(theme.textMain),
+      align: 'center',
+      valign: 'middle',
+    });
+  });
+
+  const markerW = 1.58;
+  const markerX = Math.max(GEO.marginX, Math.min(SLIDE_SIZE.width - GEO.marginX - markerW, activeCenterX - markerW / 2));
+  slide.addShape('roundRect', {
+    x: markerX,
+    y: GEO.markerY,
+    w: markerW,
+    h: 0.32,
+    rectRadius: RADIUS.panel,
+    fill: { color: clean(theme.bgMain) },
+    line: { color: clean(theme.bgMain), width: 0 },
+  });
+  addTextFr(slide, formatThreshold(spec.activeThreshold), {
+    x: markerX,
+    y: GEO.markerY + 0.02,
+    w: markerW,
+    h: 0.24,
+    fontSize: 9,
+    color: clean(theme.textOnMain),
+    bold: true,
+    align: 'center',
+    valign: 'middle',
+  });
+}
+
+function drawFiscalTable(
+  slide: PptxGenJS.Slide,
+  spec: PerFiscalSnapshotSlideSpec,
+  theme: PptxThemeRoles,
+): void {
+  addCardPanelWithShadow(slide, { x: GEO.tableX, y: GEO.tableY, w: GEO.tableW, h: GEO.tableH }, theme);
+
+  const rows = [
+    { label: 'Revenu imposable du foyer', value: euro(spec.revenuImposableFoyer) },
+    { label: 'Nombre de parts', value: spec.partsNb.toLocaleString('fr-FR', { maximumFractionDigits: 2 }) },
+    { label: 'TMI', value: pct(spec.tmiRate) },
+    { label: 'Marge restante dans la TMI', value: euro(spec.montantDansLaTMI) },
+    { label: 'Estimation de votre IR', value: euro(spec.irEstime), strong: true },
+  ];
+
+  const rowH = GEO.tableH / rows.length;
+  rows.forEach((row, index) => {
+    const y = GEO.tableY + index * rowH;
+    if (row.strong) {
+      slide.addShape('rect', {
+        x: GEO.tableX + 0.05,
+        y: y + 0.03,
+        w: GEO.tableW - 0.10,
+        h: rowH - 0.06,
+        fill: { color: clean(theme.accent), transparency: 82 },
+        line: { color: clean(theme.accent), transparency: 100 },
+      });
+    } else if (index > 0) {
+      slide.addShape('line', {
+        x: GEO.tableX + 0.45,
+        y,
+        w: GEO.tableW - 0.90,
+        h: 0,
+        line: { color: roleColor(theme, 'panelBorder'), width: 0.5 },
+      });
+    }
+
+    addTextFr(slide, row.label, {
+      x: GEO.tableX + 0.55,
+      y: y + 0.08,
+      w: 5.9,
+      h: rowH - 0.08,
+      fontSize: row.strong ? 12 : 11,
+      color: roleColor(theme, 'textBody'),
+      bold: !!row.strong,
+      align: 'left',
+      valign: 'middle',
+    });
+    addTextFr(slide, row.value, {
+      x: GEO.tableX + 6.65,
+      y: y + 0.08,
+      w: 3.0,
+      h: rowH - 0.08,
+      fontSize: row.strong ? 14 : 12,
+      color: roleColor(theme, 'textMain'),
+      bold: true,
+      align: 'right',
+      valign: 'middle',
+    });
+  });
+}
+
+export function buildPerFiscalSnapshot(
+  pptx: PptxGenJS,
+  spec: PerFiscalSnapshotSlideSpec,
+  ctx: ExportContext,
+  slideIndex: number,
+): void {
+  const slide = pptx.addSlide({ masterName: MASTER_NAMES.CONTENT });
+  const { theme } = ctx;
+
+  addHeader(slide, spec.title, spec.subtitle, theme, 'content');
+  drawTmiScale(slide, spec, theme);
+  drawFiscalTable(slide, spec, theme);
+  addFooter(slide, ctx, slideIndex, 'onLight');
+}
+
+export default buildPerFiscalSnapshot;

--- a/src/pptx/slides/buildPerPlafond3Col.ts
+++ b/src/pptx/slides/buildPerPlafond3Col.ts
@@ -1,0 +1,197 @@
+import type PptxGenJS from 'pptxgenjs';
+import type { ExportContext, PerPlafond3ColSlideSpec, PerPlafondColumn } from '../theme/types';
+import {
+  RADIUS,
+  TYPO,
+  addCardPanelWithShadow,
+  addFooter,
+  addHeader,
+  addTextFr,
+  roleColor,
+} from '../designSystem/serenity';
+import { addBusinessIconDirect } from '../icons/addBusinessIcon';
+import { MASTER_NAMES } from '../template/loadBaseTemplate';
+
+const GEO = {
+  marginX: 0.92,
+  introY: 1.82,
+  panelX: 0.92,
+  panelY: 2.52,
+  panelW: 11.5,
+  panelH: 3.5,
+  noteY: 6.18,
+} as const;
+
+function euro(value: number): string {
+  return new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  }).format(Math.round(value || 0));
+}
+
+function clean(color: string): string {
+  return color.replace('#', '');
+}
+
+function variantColor(spec: PerPlafond3ColSlideSpec, theme: ExportContext['theme']): string {
+  return clean(spec.variant === 'madelin' ? theme.colors.color3 : theme.colors.color5);
+}
+
+function drawColumn(
+  slide: PptxGenJS.Slide,
+  column: PerPlafondColumn,
+  index: number,
+  spec: PerPlafond3ColSlideSpec,
+  ctx: ExportContext,
+): void {
+  const { theme } = ctx;
+  const accent = variantColor(spec, theme);
+  const colW = GEO.panelW / 3;
+  const x = GEO.panelX + index * colW;
+  const innerX = x + 0.32;
+  const centerX = x + colW / 2;
+
+  if (index > 0) {
+    slide.addShape('line', {
+      x,
+      y: GEO.panelY + 0.34,
+      w: 0,
+      h: GEO.panelH - 0.68,
+      line: { color: roleColor(theme, 'panelBorder'), width: 0.75 },
+    });
+  }
+
+  slide.addShape('roundRect', {
+    x: centerX - 0.28,
+    y: GEO.panelY + 0.35,
+    w: 0.56,
+    h: 0.56,
+    rectRadius: RADIUS.panel,
+    fill: { color: accent, transparency: 86 },
+    line: { color: accent, transparency: 100 },
+  });
+  addBusinessIconDirect(slide, column.iconName, {
+    x: centerX - 0.15,
+    y: GEO.panelY + 0.48,
+    w: 0.30,
+    h: 0.30,
+    color: `#${accent}`,
+  });
+
+  addTextFr(slide, column.heading, {
+    x: x + 0.22,
+    y: GEO.panelY + 1.02,
+    w: colW - 0.44,
+    h: 0.44,
+    fontSize: 11,
+    color: roleColor(theme, 'textMain'),
+    bold: true,
+    align: 'center',
+    valign: 'middle',
+  });
+
+  const d1Y = GEO.panelY + 1.76;
+  addTextFr(slide, 'Déclarant 1', {
+    x: innerX,
+    y: d1Y,
+    w: colW - 0.64,
+    h: 0.18,
+    fontSize: 8,
+    color: roleColor(theme, 'textBody'),
+    bold: true,
+  });
+  addTextFr(slide, euro(column.values.declarant1), {
+    x: innerX,
+    y: d1Y + 0.20,
+    w: colW - 0.64,
+    h: 0.34,
+    fontSize: 17,
+    color: accent,
+    bold: true,
+  });
+
+  if (spec.isCouple) {
+    slide.addShape('line', {
+      x: innerX,
+      y: d1Y + 0.74,
+      w: colW - 0.64,
+      h: 0,
+      line: { color: roleColor(theme, 'panelBorder'), width: 0.5 },
+    });
+    addTextFr(slide, 'Déclarant 2', {
+      x: innerX,
+      y: d1Y + 0.92,
+      w: colW - 0.64,
+      h: 0.18,
+      fontSize: 8,
+      color: roleColor(theme, 'textBody'),
+      bold: true,
+    });
+    addTextFr(slide, euro(column.values.declarant2 ?? 0), {
+      x: innerX,
+      y: d1Y + 1.12,
+      w: colW - 0.64,
+      h: 0.34,
+      fontSize: 17,
+      color: accent,
+      bold: true,
+    });
+  }
+
+  if (column.caption) {
+    addTextFr(slide, column.caption, {
+      x: x + 0.30,
+      y: GEO.panelY + GEO.panelH - 0.42,
+      w: colW - 0.60,
+      h: 0.22,
+      fontSize: 8,
+      color: roleColor(theme, 'textBody'),
+      italic: true,
+      align: 'center',
+      valign: 'middle',
+    });
+  }
+}
+
+export function buildPerPlafond3Col(
+  pptx: PptxGenJS,
+  spec: PerPlafond3ColSlideSpec,
+  ctx: ExportContext,
+  slideIndex: number,
+): void {
+  const slide = pptx.addSlide({ masterName: MASTER_NAMES.CONTENT });
+  const { theme } = ctx;
+
+  addHeader(slide, spec.title, spec.subtitle, theme, 'content', 22, TYPO.sizes.h2);
+  addTextFr(slide, spec.intro, {
+    x: GEO.marginX,
+    y: GEO.introY,
+    w: 11.5,
+    h: 0.48,
+    fontSize: 11,
+    color: roleColor(theme, 'textBody'),
+    valign: 'middle',
+  });
+
+  addCardPanelWithShadow(slide, { x: GEO.panelX, y: GEO.panelY, w: GEO.panelW, h: GEO.panelH }, theme);
+  spec.columns.forEach((column, index) => drawColumn(slide, column, index, spec, ctx));
+
+  if (spec.note) {
+    addTextFr(slide, spec.note, {
+      x: GEO.marginX,
+      y: GEO.noteY,
+      w: 11.5,
+      h: 0.28,
+      fontSize: 9,
+      color: roleColor(theme, 'textBody'),
+      italic: true,
+      align: 'center',
+      valign: 'middle',
+    });
+  }
+
+  addFooter(slide, ctx, slideIndex, 'onLight');
+}
+
+export default buildPerPlafond3Col;

--- a/src/pptx/slides/buildPerProjectionTable.ts
+++ b/src/pptx/slides/buildPerProjectionTable.ts
@@ -1,0 +1,192 @@
+import type PptxGenJS from 'pptxgenjs';
+import type { ExportContext, PerProjectionRow, PerProjectionTableSlideSpec, PerSimulationRow } from '../theme/types';
+import {
+  RADIUS,
+  TYPO,
+  addCardPanelWithShadow,
+  addFooter,
+  addHeader,
+  addTextFr,
+  roleColor,
+} from '../designSystem/serenity';
+import { MASTER_NAMES } from '../template/loadBaseTemplate';
+
+const GEO = {
+  panelX: 2.16,
+  panelY: 1.82,
+  panelW: 9.0,
+  panelH: 4.9,
+  rowH: 0.30,
+  sectionH: 0.32,
+} as const;
+
+function euro(value: number): string {
+  return new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: 'EUR',
+    maximumFractionDigits: 0,
+  }).format(Math.round(value || 0));
+}
+
+function displayValue(value: number | string | boolean | undefined): string {
+  if (typeof value === 'number') return euro(value);
+  if (typeof value === 'boolean') return value ? 'Oui' : 'Non';
+  return value ?? '—';
+}
+
+function drawSectionHeader(
+  slide: PptxGenJS.Slide,
+  label: string,
+  y: number,
+  ctx: ExportContext,
+): void {
+  const { theme } = ctx;
+  slide.addShape('roundRect', {
+    x: GEO.panelX + 0.24,
+    y,
+    w: GEO.panelW - 0.48,
+    h: GEO.sectionH,
+    rectRadius: RADIUS.panel,
+    fill: { color: roleColor(theme, 'accent'), transparency: 82 },
+    line: { color: roleColor(theme, 'accent'), transparency: 100 },
+  });
+  addTextFr(slide, label, {
+    x: GEO.panelX + 0.40,
+    y: y + 0.04,
+    w: GEO.panelW - 0.80,
+    h: 0.20,
+    fontSize: 9,
+    color: roleColor(theme, 'textMain'),
+    bold: true,
+    align: 'left',
+    valign: 'middle',
+  });
+}
+
+function drawRows(
+  slide: PptxGenJS.Slide,
+  rows: PerProjectionRow[],
+  yStart: number,
+  isCouple: boolean,
+  ctx: ExportContext,
+): number {
+  const { theme } = ctx;
+  const labelW = isCouple ? 4.20 : 5.95;
+  const valueW = isCouple ? 1.80 : 2.20;
+  const d1X = GEO.panelX + 0.52 + labelW;
+  const d2X = d1X + valueW + 0.35;
+
+  if (isCouple) {
+    addTextFr(slide, 'D1', {
+      x: d1X,
+      y: yStart - 0.20,
+      w: valueW,
+      h: 0.16,
+      fontSize: 8,
+      color: roleColor(theme, 'textBody'),
+      bold: true,
+      align: 'right',
+    });
+    addTextFr(slide, 'D2', {
+      x: d2X,
+      y: yStart - 0.20,
+      w: valueW,
+      h: 0.16,
+      fontSize: 8,
+      color: roleColor(theme, 'textBody'),
+      bold: true,
+      align: 'right',
+    });
+  }
+
+  rows.forEach((row, index) => {
+    const y = yStart + index * GEO.rowH;
+    if (index % 2 === 1) {
+      slide.addShape('rect', {
+        x: GEO.panelX + 0.30,
+        y: y + 0.02,
+        w: GEO.panelW - 0.60,
+        h: GEO.rowH - 0.04,
+        fill: { color: roleColor(theme, 'panelBorder'), transparency: 76 },
+        line: { color: roleColor(theme, 'panelBorder'), transparency: 100 },
+      });
+    }
+    addTextFr(slide, row.label, {
+      x: GEO.panelX + 0.52,
+      y: y + 0.05,
+      w: labelW,
+      h: 0.18,
+      fontSize: 8.5,
+      color: roleColor(theme, 'textBody'),
+      valign: 'middle',
+    });
+    addTextFr(slide, displayValue(row.declarant1), {
+      x: d1X,
+      y: y + 0.05,
+      w: valueW,
+      h: 0.18,
+      fontSize: 9,
+      color: roleColor(theme, 'textMain'),
+      bold: true,
+      align: 'right',
+      valign: 'middle',
+    });
+    if (isCouple) {
+      addTextFr(slide, displayValue(row.declarant2), {
+        x: d2X,
+        y: y + 0.05,
+        w: valueW,
+        h: 0.18,
+        fontSize: 9,
+        color: roleColor(theme, 'textMain'),
+        bold: true,
+        align: 'right',
+        valign: 'middle',
+      });
+    }
+  });
+
+  return yStart + rows.length * GEO.rowH;
+}
+
+function drawSimulationRows(
+  slide: PptxGenJS.Slide,
+  rows: PerSimulationRow[],
+  yStart: number,
+  ctx: ExportContext,
+): number {
+  const convertedRows: PerProjectionRow[] = rows.map((row) => ({
+    label: row.label,
+    declarant1: row.value,
+  }));
+  return drawRows(slide, convertedRows, yStart, false, ctx);
+}
+
+export function buildPerProjectionTable(
+  pptx: PptxGenJS,
+  spec: PerProjectionTableSlideSpec,
+  ctx: ExportContext,
+  slideIndex: number,
+): void {
+  const slide = pptx.addSlide({ masterName: MASTER_NAMES.CONTENT });
+  const { theme } = ctx;
+
+  addHeader(slide, spec.title, spec.subtitle, theme, 'content', 21, TYPO.sizes.h2);
+  addCardPanelWithShadow(slide, { x: GEO.panelX, y: GEO.panelY, w: GEO.panelW, h: GEO.panelH }, theme);
+
+  let y = GEO.panelY + 0.35;
+  drawSectionHeader(slide, 'Cases 2042 à reporter', y, ctx);
+  y = drawRows(slide, spec.declarationRows, y + GEO.sectionH + 0.22, spec.isCouple, ctx) + 0.22;
+
+  drawSectionHeader(slide, "Projection du prochain avis d'impôt", y, ctx);
+  y = drawRows(slide, spec.avisRows, y + GEO.sectionH + 0.22, spec.isCouple, ctx) + 0.22;
+
+  if (spec.simulationRows && spec.simulationRows.length > 0 && y < GEO.panelY + GEO.panelH - 0.72) {
+    drawSectionHeader(slide, 'Impact du versement envisagé', y, ctx);
+    drawSimulationRows(slide, spec.simulationRows, y + GEO.sectionH + 0.20, ctx);
+  }
+
+  addFooter(slide, ctx, slideIndex, 'onLight');
+}
+
+export default buildPerProjectionTable;

--- a/src/pptx/slides/index.ts
+++ b/src/pptx/slides/index.ts
@@ -11,6 +11,9 @@ export { buildEnd } from './buildEnd';
 
 export { buildIrSynthesis } from './buildIrSynthesis';
 export { buildIrAnnexe } from './buildIrAnnexe';
+export { buildPerFiscalSnapshot } from './buildPerFiscalSnapshot';
+export { buildPerPlafond3Col } from './buildPerPlafond3Col';
+export { buildPerProjectionTable } from './buildPerProjectionTable';
 
 export { buildCreditSynthesis } from './buildCreditSynthesis';
 export { buildCreditGlobalSynthesis } from './buildCreditGlobalSynthesis';

--- a/src/pptx/theme/types.ts
+++ b/src/pptx/theme/types.ts
@@ -297,6 +297,72 @@ export type PlacementProjectionSlideSpec = {
 };
 
 /**
+ * PER — Situation fiscale avec échelle TMI.
+ */
+export type PerFiscalBracket = {
+  label: string;
+  rate: number;
+  threshold: number | null;
+};
+
+export type PerFiscalSnapshotSlideSpec = {
+  type: 'per-fiscal-snapshot';
+  title: string;
+  subtitle: string;
+  tmiRate: number;
+  activeThreshold: number | null;
+  irEstime: number;
+  revenuImposableFoyer: number;
+  partsNb: number;
+  montantDansLaTMI: number;
+  brackets: PerFiscalBracket[];
+};
+
+export type PerDeclarantValues = {
+  declarant1: number;
+  declarant2?: number | undefined;
+};
+
+export type PerPlafondColumn = {
+  heading: string;
+  iconName: BusinessIconName;
+  values: PerDeclarantValues;
+  caption?: string;
+};
+
+export type PerPlafond3ColSlideSpec = {
+  type: 'per-plafond-3col';
+  title: string;
+  subtitle: string;
+  variant: '163q' | 'madelin';
+  intro: string;
+  columns: [PerPlafondColumn, PerPlafondColumn, PerPlafondColumn];
+  isCouple: boolean;
+  note?: string;
+};
+
+export type PerProjectionRow = {
+  label: string;
+  declarant1: number | string | boolean;
+  declarant2?: number | string | boolean | undefined;
+};
+
+export type PerSimulationRow = {
+  label: string;
+  value: number | string;
+};
+
+export type PerProjectionTableSlideSpec = {
+  type: 'per-projection-table';
+  title: string;
+  subtitle: string;
+  isCouple: boolean;
+  declarationRows: PerProjectionRow[];
+  avisRows: PerProjectionRow[];
+  simulationRows?: PerSimulationRow[];
+};
+
+/**
  * End/Legal Slide Specification
  */
 export type EndSlideSpec = {
@@ -476,6 +542,9 @@ export type StudyDeckSpec = {
     | PlacementDetailSlideSpec
     | PlacementHypothesesSlideSpec
     | PlacementProjectionSlideSpec
+    | PerFiscalSnapshotSlideSpec
+    | PerPlafond3ColSlideSpec
+    | PerProjectionTableSlideSpec
   >;
   end: EndSlideSpec;
 };

--- a/tests/snapshots/__snapshots__/per-pptx-spec.test.ts.snap
+++ b/tests/snapshots/__snapshots__/per-pptx-spec.test.ts.snap
@@ -1,0 +1,182 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`snapshots/per: PPTX deck spec > produit la nouvelle structure visuelle hors TNS 1`] = `
+{
+  "cover": {
+    "leftMeta": "<DATE>",
+    "logoPlacement": undefined,
+    "logoUrl": undefined,
+    "rightMeta": "Conseiller en gestion de patrimoine",
+    "subtitle": "Contrôle du potentiel épargne retraite",
+    "title": "Étude — Potentiel épargne retraite",
+    "type": "cover",
+  },
+  "end": {
+    "legalText": "Document établi à titre strictement indicatif et dépourvu de valeur contractuelle. Il a été élaboré sur la base des dispositions légales et réglementaires en vigueur à la date de sa remise, lesquelles sont susceptibles d'évoluer.
+
+Les informations qu'il contient sont strictement confidentielles et destinées exclusivement aux personnes expressément autorisées.
+
+Toute reproduction, représentation, diffusion ou rediffusion, totale ou partielle, sur quelque support ou par quelque procédé que ce soit, ainsi que toute vente, revente, retransmission ou mise à disposition de tiers, est strictement encadrée. Le non-respect de ces dispositions est susceptible de constituer une contrefaçon engageant la responsabilité civile et pénale de son auteur, conformément aux articles L335-1 à L335-10 du Code de la propriété intellectuelle.",
+    "type": "end",
+  },
+  "slides": [
+    {
+      "body": "Vous partez de l'avis IR précédent, reconstituez les revenus et versements de l'année, puis estimez le potentiel disponible pour arbitrer un versement.",
+      "chapterImageIndex": 4,
+      "subtitle": "Contrôle du potentiel épargne retraite — Avis IR précédent et reconstitution",
+      "title": "Objectifs & contexte",
+      "type": "chapter",
+    },
+    {
+      "activeThreshold": 29316,
+      "brackets": [
+        {
+          "label": "0 %",
+          "rate": 0,
+          "threshold": 0,
+        },
+        {
+          "label": "11 %",
+          "rate": 11,
+          "threshold": 11498,
+        },
+        {
+          "label": "30 %",
+          "rate": 30,
+          "threshold": 29316,
+        },
+        {
+          "label": "41 %",
+          "rate": 41,
+          "threshold": 83824,
+        },
+        {
+          "label": "45 %",
+          "rate": 45,
+          "threshold": 180295,
+        },
+      ],
+      "irEstime": 20620.14,
+      "montantDansLaTMI": 53346,
+      "partsNb": 2,
+      "revenuImposableFoyer": 127000,
+      "subtitle": "2025 (revenus 2024)",
+      "title": "Estimation de la situation fiscale",
+      "tmiRate": 0.3,
+      "type": "per-fiscal-snapshot",
+    },
+    {
+      "columns": [
+        {
+          "heading": "Disponible après mutualisation",
+          "iconName": "bank",
+          "values": {
+            "declarant1": 0,
+            "declarant2": 0,
+          },
+        },
+        {
+          "heading": "Versements retenus pour l’IR",
+          "iconName": "pen",
+          "values": {
+            "declarant1": 0,
+            "declarant2": 0,
+          },
+        },
+        {
+          "heading": "Disponible restant",
+          "iconName": "gauge",
+          "values": {
+            "declarant1": 0,
+            "declarant2": 0,
+          },
+        },
+      ],
+      "intro": "Le potentiel personnel correspond au plafond 163 quatervicies, calculé sur les revenus professionnels et les reliquats reportables. Pour l'année de référence, le PASS retenu est 47 100 €.",
+      "isCouple": true,
+      "note": "Mutualisation des plafonds activée : les disponibles du conjoint peuvent absorber un dépassement.",
+      "subtitle": "Disponible, versements retenus et solde",
+      "title": "Plafonds épargne retraite 163Q pour 2025",
+      "type": "per-plafond-3col",
+      "variant": "163q",
+    },
+    {
+      "avisRows": [
+        {
+          "declarant1": 0,
+          "declarant2": 0,
+          "label": "Reliquat N-2",
+        },
+        {
+          "declarant1": 0,
+          "declarant2": 0,
+          "label": "Reliquat N-1",
+        },
+        {
+          "declarant1": 0,
+          "declarant2": 0,
+          "label": "Reliquat N",
+        },
+        {
+          "declarant1": 7650,
+          "declarant2": 4710,
+          "label": "Plafond calculé",
+        },
+        {
+          "declarant1": 7650,
+          "declarant2": 4710,
+          "label": "Total projeté",
+        },
+      ],
+      "declarationRows": [
+        {
+          "declarant1": 4000,
+          "declarant2": 0,
+          "label": "6NS / 6NT — PER 163 quatervicies",
+        },
+        {
+          "declarant1": 0,
+          "declarant2": 1200,
+          "label": "6RS / 6RT — PERP et assimilés",
+        },
+        {
+          "declarant1": 0,
+          "declarant2": 0,
+          "label": "6OS / 6OT — PER 154 bis",
+        },
+        {
+          "declarant1": 0,
+          "declarant2": 0,
+          "label": "6QS / 6QT — Madelin, PERCO, Art. 83",
+        },
+        {
+          "declarant1": true,
+          "label": "6QR — Mutualisation conjoint",
+        },
+      ],
+      "isCouple": true,
+      "simulationRows": [
+        {
+          "label": "Versement envisagé",
+          "value": 9000,
+        },
+        {
+          "label": "Versement déductible retenu",
+          "value": 0,
+        },
+        {
+          "label": "Économie d'IR estimée",
+          "value": 0,
+        },
+        {
+          "label": "Coût net après fiscalité",
+          "value": 9000,
+        },
+      ],
+      "subtitle": "Synthèse des reports et reliquats projetés",
+      "title": "Déclaration 2042 et prochain avis d'impôt",
+      "type": "per-projection-table",
+    },
+  ],
+}
+`;

--- a/tests/snapshots/per-pptx-spec.test.ts
+++ b/tests/snapshots/per-pptx-spec.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_PASS_HISTORY, DEFAULT_PS_SETTINGS, DEFAULT_TAX_SETTINGS } from '../../src/constants/settingsDefaults';
+import { calculatePerPotentiel } from '../../src/engine/per';
+import { buildPerStudyDeck } from '../../src/pptx/presets/perDeckBuilder';
+import { DEFAULT_COLORS } from '../../src/settings/theme';
+
+function declarant(overrides: Record<string, number | boolean> = {}) {
+  return {
+    statutTns: false,
+    salaires: 0,
+    fraisReels: false,
+    fraisReelsMontant: 0,
+    art62: 0,
+    bic: 0,
+    retraites: 0,
+    fonciersNets: 0,
+    autresRevenus: 0,
+    cotisationsPer163Q: 0,
+    cotisationsPerp: 0,
+    cotisationsArt83: 0,
+    cotisationsMadelin154bis: 0,
+    cotisationsMadelinRetraite: 0,
+    abondementPerco: 0,
+    cotisationsPrevo: 0,
+    ...overrides,
+  };
+}
+
+function buildResult(isTns = false) {
+  return calculatePerPotentiel({
+    mode: 'versement-n',
+    historicalBasis: 'previous-avis-plus-n1',
+    anneeRef: 2025,
+    situationFiscale: {
+      situationFamiliale: 'marie',
+      nombreParts: 2,
+      isole: false,
+      declarant1: declarant({
+        salaires: isTns ? 0 : 85000,
+        statutTns: isTns,
+        bic: isTns ? 72000 : 0,
+        cotisationsPer163Q: 4000,
+        cotisationsMadelin154bis: isTns ? 2500 : 0,
+        cotisationsMadelinRetraite: isTns ? 3000 : 0,
+        cotisationsPrevo: isTns ? 600 : 0,
+      }),
+      declarant2: declarant({ salaires: 42000, cotisationsPerp: 1200 }),
+    },
+    versementEnvisage: 9000,
+    mutualisationConjoints: true,
+    passHistory: DEFAULT_PASS_HISTORY,
+    taxSettings: DEFAULT_TAX_SETTINGS,
+    psSettings: DEFAULT_PS_SETTINGS,
+  });
+}
+
+function buildData(isTns = false) {
+  return {
+    mode: 'versement-n' as const,
+    historicalBasis: 'previous-avis-plus-n1' as const,
+    needsCurrentYearEstimate: false,
+    situationFamiliale: 'marie' as const,
+    nombreParts: 2,
+    isole: false,
+    mutualisationConjoints: true,
+    versementEnvisage: 9000,
+    result: buildResult(isTns),
+    anneeRef: 2025,
+    passReference: DEFAULT_PASS_HISTORY[2025] ?? 0,
+    irScale: DEFAULT_TAX_SETTINGS.incomeTax.scaleCurrent,
+    irScaleLabel: DEFAULT_TAX_SETTINGS.incomeTax.currentYearLabel,
+  };
+}
+
+describe('snapshots/per: PPTX deck spec', () => {
+  it('produit la nouvelle structure visuelle hors TNS', () => {
+    const spec = buildPerStudyDeck(buildData(false), DEFAULT_COLORS);
+
+    expect(spec.slides.map((slide) => slide.type)).toEqual([
+      'chapter',
+      'per-fiscal-snapshot',
+      'per-plafond-3col',
+      'per-projection-table',
+    ]);
+
+    const sanitized = {
+      ...spec,
+      cover: {
+        ...spec.cover,
+        leftMeta: '<DATE>',
+      },
+    };
+
+    expect(sanitized).toMatchSnapshot();
+  });
+
+  it('ajoute la slide Madelin lorsque le foyer comporte un TNS', () => {
+    const spec = buildPerStudyDeck(buildData(true), DEFAULT_COLORS);
+    const madelinSlides = spec.slides.filter((slide) => (
+      slide.type === 'per-plafond-3col' && slide.variant === 'madelin'
+    ));
+
+    expect(madelinSlides).toHaveLength(1);
+    expect(spec.slides.map((slide) => slide.type)).toEqual([
+      'chapter',
+      'per-fiscal-snapshot',
+      'per-plafond-3col',
+      'per-plafond-3col',
+      'per-projection-table',
+    ]);
+  });
+});


### PR DESCRIPTION
## Description
Refonte de l'étude PowerPoint générée depuis `/sim/per/potentiel` et correction du potentiel 163 quatervicies affiché dans la carte `Potentiel` sur la tab `Versement N`.

## Changements
- Ajout de trois builders PPTX PER dédiés : situation fiscale/TMI, plafonds en 3 colonnes, déclaration 2042 + prochain avis IR.
- Réécriture du preset PowerPoint PER pour produire une étude plus visuelle, sans recalcul fiscal dans les slide builders.
- Passage du barème IR et du PASS depuis le contexte fiscal vers l'export PPTX.
- Correction de la carte `Potentiel` pour afficher le disponible 163Q recalculé après saisie sur `Versement N`, y compris en partant de l'avis IR 2025.
- Ajout et mise à jour des tests PER + snapshot PPTX.

## Fonctionnalités
- Le PowerPoint PER affiche désormais une synthèse fiscale visuelle, les plafonds 163Q, la slide Madelin conditionnelle TNS et la projection déclarative.
- Sur `Versement N`, le potentiel 163 quatervicies restant s'ajuste automatiquement aux versements saisis, comme sur `Revenus 2025`.

## Tests effectués
- [x] `npm run lint` passe
- [x] `npm run typecheck` passe
- [x] `npm test` passe
- [x] `npm run build` passe
- [x] `npm run check` passe (si utilisé comme agrégat)
- [x] `powershell -ExecutionPolicy Bypass -File .\scripts\pre-merge-check.ps1` passe

## Notes
Pas de changement de moteur fiscal. Les valeurs fiscales affichées dans le PowerPoint sont issues du contexte fiscal et du résultat moteur existant.

## Checklist
- [x] Pas de push direct sur `main`
- [x] Pas de fichiers temporaires ajoutés à la racine
- [x] Documentation mise à jour si nécessaire