### PR TITLE
Verrouiller le parcours simplifié du potentiel PER

### DIFF
--- a/src/features/per/components/potentiel/PerPotentielSimulator.test.tsx
+++ b/src/features/per/components/potentiel/PerPotentielSimulator.test.tsx
@@ -1,7 +1,10 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockUsePerPotentiel = vi.fn();
+const mockUsePerPotentiel = vi.hoisted(() => vi.fn());
+const mockUserModeState = vi.hoisted(() => ({
+  mode: 'expert' as 'expert' | 'simplifie',
+}));
 
 vi.mock('../../../../hooks/useFiscalContext', () => ({
   useFiscalContext: () => ({
@@ -27,7 +30,7 @@ vi.mock('../../../../settings/ThemeProvider', () => ({
 
 vi.mock('../../../../settings/userMode', () => ({
   useUserMode: () => ({
-    mode: 'expert',
+    mode: mockUserModeState.mode,
   }),
 }));
 
@@ -217,6 +220,7 @@ describe('PerPotentielSimulator', () => {
   beforeEach(() => {
     mockUsePerPotentiel.mockReset();
     mockUsePerPotentiel.mockReturnValue(makeHookReturn(2));
+    mockUserModeState.mode = 'expert';
   });
 
   it('passes declarant totals to the avis step and shows them in the right sidebar', () => {
@@ -334,5 +338,13 @@ describe('PerPotentielSimulator', () => {
     expect(html).toContain('per-potentiel-stage-header sim-card__header sim-card__header--bleed');
     expect(html).toContain('class="sim-card__title-row"');
     expect(html).toContain('Lecture de l&#x27;avis IR 2025');
+  });
+
+  it('force le preset simplifié côté hook quand le mode utilisateur est simplifié', () => {
+    mockUserModeState.mode = 'simplifie';
+
+    renderToStaticMarkup(<PerPotentielSimulator />);
+
+    expect(mockUsePerPotentiel).toHaveBeenCalledWith(expect.any(Object), { simplifiedMode: true });
   });
 });

--- a/src/features/per/components/potentiel/PerPotentielSimulator.tsx
+++ b/src/features/per/components/potentiel/PerPotentielSimulator.tsx
@@ -97,6 +97,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
   const [localMode, setLocalMode] = useState<UserMode | null>(null);
   const [incomeFilters, setIncomeFilters] = useState<PerIncomeFilters>(DEFAULT_INCOME_FILTERS);
   const isExpert = (localMode ?? mode) === 'expert';
+  const isSimplified = !isExpert;
   const toggleMode = () => setLocalMode(isExpert ? 'simplifie' : 'expert');
   const years = getPerWorkflowYears(fiscalContext);
 
@@ -120,7 +121,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
     removeProjectionChild,
     goToStep,
     reset,
-  } = usePerPotentiel(fiscalContext);
+  } = usePerPotentiel(fiscalContext, { simplifiedMode: isSimplified });
 
   useEffect(() => {
     const off = onResetEvent(({ simId }: { simId?: string }) => {
@@ -284,6 +285,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
               onSelectMode={setMode}
               onSelectHistoricalBasis={setHistoricalBasis}
               onSetNeedsCurrentYearEstimate={setNeedsCurrentYearEstimate}
+              simplifiedMode={isSimplified}
             />
           ) : (
           <div className="premium-card premium-card--guide per-potentiel-stage">

--- a/src/features/per/components/potentiel/steps/ModeStep.test.tsx
+++ b/src/features/per/components/potentiel/steps/ModeStep.test.tsx
@@ -1,0 +1,58 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import ModeStep from './ModeStep';
+import type { PerWorkflowYears } from '../../../utils/perWorkflowYears';
+
+const years: PerWorkflowYears = {
+  currentTaxLabel: '2026 (revenus 2025)',
+  previousTaxLabel: '2025 (revenus 2024)',
+  currentTaxYear: 2026,
+  currentIncomeYear: 2025,
+  previousTaxYear: 2025,
+  previousIncomeYear: 2024,
+};
+
+const handlers = {
+  onSelectMode: vi.fn(),
+  onSelectHistoricalBasis: vi.fn(),
+  onSetNeedsCurrentYearEstimate: vi.fn(),
+};
+
+describe('ModeStep', () => {
+  it('verrouille le parcours simplifié sur avis IR courant sans projection', () => {
+    const html = renderToStaticMarkup(
+      <ModeStep
+        mode="versement-n"
+        historicalBasis="current-avis"
+        needsCurrentYearEstimate={false}
+        years={years}
+        simplifiedMode
+        {...handlers}
+      />,
+    );
+
+    expect(html).toContain('Parcours simplifié');
+    expect(html).toContain('Contrôle du potentiel avant versement');
+    expect(html).toContain('Avis IR 2026 disponible');
+    expect(html).toContain('Projection désactivée');
+    expect(html).not.toContain('Reporter dans la déclaration 2042');
+    expect(html).not.toContain('mode-toggle-pill');
+  });
+
+  it('conserve les choix complets en mode expert', () => {
+    const html = renderToStaticMarkup(
+      <ModeStep
+        mode="versement-n"
+        historicalBasis="current-avis"
+        needsCurrentYearEstimate={false}
+        years={years}
+        {...handlers}
+      />,
+    );
+
+    expect(html).toContain('Reporter dans la déclaration 2042');
+    expect(html).toContain('Avis IR 2025 disponible');
+    expect(html).toContain('Avis IR 2026 disponible');
+    expect(html).toContain('mode-toggle-pill');
+  });
+});

--- a/src/features/per/components/potentiel/steps/ModeStep.tsx
+++ b/src/features/per/components/potentiel/steps/ModeStep.tsx
@@ -15,6 +15,7 @@ interface ModeStepProps {
   onSelectMode: (_mode: PerMode) => void;
   onSelectHistoricalBasis: (_basis: PerHistoricalBasis) => void;
   onSetNeedsCurrentYearEstimate: (_value: boolean) => void;
+  simplifiedMode?: boolean;
 }
 
 export default function ModeStep({
@@ -25,6 +26,7 @@ export default function ModeStep({
   onSelectMode,
   onSelectHistoricalBasis,
   onSetNeedsCurrentYearEstimate,
+  simplifiedMode = false,
 }: ModeStepProps): React.ReactElement {
   const modes: { id: PerMode; title: string; desc: string; marker: string }[] = [
     {
@@ -40,6 +42,77 @@ export default function ModeStep({
       marker: 'Déclaration N-1',
     },
   ];
+
+  if (simplifiedMode) {
+    return (
+      <div className="per-step per-step--mode">
+        <div className="premium-card sim-card--guide per-mode-step-card">
+          <div className="per-mode-step-header sim-card__header--bleed">
+            <div className="sim-card__title-row">
+              <div className="sim-card__icon">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+                </svg>
+              </div>
+              <h3 className="sim-card__title">Parcours simplifié</h3>
+            </div>
+          </div>
+          <div className="sim-divider" />
+
+          <div className="per-mode-grid">
+            <div className="per-mode-card per-mode-card--selected per-mode-card--locked" aria-disabled="true">
+              <span className="per-mode-card-marker">Versement N</span>
+              <h4 className="per-mode-card-title">Contrôle du potentiel avant versement</h4>
+              <p className="per-mode-card-desc">
+                Parcours préselectionné à partir de l&apos;avis IR {years.currentTaxYear},
+                sans projection de l&apos;année en cours.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="premium-card sim-card--guide per-mode-support-card">
+          <div className="per-mode-docs-header sim-card__header--bleed">
+            <div className="sim-card__title-row">
+              <div className="sim-card__icon">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                  <polyline points="14 2 14 8 20 8" />
+                </svg>
+              </div>
+              <h3 className="sim-card__title">Documents nécessaires</h3>
+            </div>
+            <p className="per-mode-docs-subtitle">Base documentaire verrouillée en mode simplifié</p>
+          </div>
+          <div className="sim-divider" />
+
+          <div className="per-mode-panel-stack">
+            <div className="per-mode-panel-block">
+              <div className="per-mode-doc-grid">
+                <div className="per-mode-doc-card is-selected per-mode-doc-card--locked" aria-disabled="true">
+                  <span className="per-mode-doc-title">
+                    Avis IR {years.currentTaxYear} disponible
+                  </span>
+                  <span className="per-mode-doc-desc">
+                    Avis sur les revenus {years.currentIncomeYear}. Le plafond épargne retraite est
+                    repris directement depuis l&apos;avis.
+                  </span>
+                </div>
+
+                <div className="per-mode-doc-card per-mode-doc-card--locked" aria-disabled="true">
+                  <span className="per-mode-doc-title">Projection désactivée</span>
+                  <span className="per-mode-doc-desc">
+                    La vérification porte uniquement sur les versements de l&apos;année en cours.
+                    Passez en mode expert pour projeter l&apos;avis suivant.
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="per-step per-step--mode">

--- a/src/features/per/hooks/usePerPotentiel.ts
+++ b/src/features/per/hooks/usePerPotentiel.ts
@@ -5,7 +5,7 @@
  * Persistence via sessionStorage.
  */
 
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import { calculatePerPotentiel } from '../../../engine/per';
 import type {
   PerPotentielInput,
@@ -22,6 +22,7 @@ import { resolvePerCalculationYear } from '../utils/perCalculationYear';
 import { projectionToAvisIrPlafonds } from '../utils/perSyntheticAvis';
 import { getNextPerChildId, normalizePerChildren, normalizePerFoyer } from '../utils/perFoyerState';
 import { buildVisibleSteps } from '../utils/perVisibleSteps';
+import { applyPerSimplifiedPreset, isPerSimplifiedPresetState } from '../utils/perSimplifiedMode';
 
 const SESSION_KEY = 'ser1:sim:per:potentiel:v4';
 
@@ -34,6 +35,9 @@ type PerSituationPatch = Partial<{
   isole: boolean;
   mutualisationConjoints: boolean;
 }>;
+interface PerPotentielStateOptions {
+  simplifiedMode?: boolean;
+}
 
 export interface PerPotentielState {
   step: WizardStep;
@@ -79,27 +83,32 @@ const EMPTY_DECLARANT: DeclarantRevenus = {
   cotisationsPrevo: 0,
 };
 
-function normalizeState(state: PerPotentielState): PerPotentielState {
-  const visibleSteps = buildVisibleSteps(state.mode, state.historicalBasis, state.needsCurrentYearEstimate);
+function normalizeState(state: PerPotentielState, options: PerPotentielStateOptions = {}): PerPotentielState {
+  const baseState = options.simplifiedMode ? applyPerSimplifiedPreset(state) : state;
+  const visibleSteps = buildVisibleSteps(
+    baseState.mode,
+    baseState.historicalBasis,
+    baseState.needsCurrentYearEstimate,
+  );
   const fallbackStep = visibleSteps[visibleSteps.length - 1] ?? 1;
-  const step = visibleSteps.includes(state.step) ? state.step : fallbackStep;
+  const step = visibleSteps.includes(baseState.step) ? baseState.step : fallbackStep;
   const foyer = normalizePerFoyer({
-    situationFamiliale: state.situationFamiliale,
-    isole: state.isole,
-    children: state.children,
-    mutualisationConjoints: state.mutualisationConjoints,
+    situationFamiliale: baseState.situationFamiliale,
+    isole: baseState.isole,
+    children: baseState.children,
+    mutualisationConjoints: baseState.mutualisationConjoints,
   });
-  const projectionFoyer = state.projectionFoyerEdited
+  const projectionFoyer = baseState.projectionFoyerEdited
     ? normalizePerFoyer({
-      situationFamiliale: state.projectionSituationFamiliale,
-      isole: state.projectionIsole,
-      children: state.projectionChildren,
-      mutualisationConjoints: state.projectionMutualisationConjoints,
+      situationFamiliale: baseState.projectionSituationFamiliale,
+      isole: baseState.projectionIsole,
+      children: baseState.projectionChildren,
+      mutualisationConjoints: baseState.projectionMutualisationConjoints,
     })
     : foyer;
 
   return {
-    ...state,
+    ...baseState,
     step,
     situationFamiliale: foyer.situationFamiliale,
     isole: foyer.isole,
@@ -114,7 +123,7 @@ function normalizeState(state: PerPotentielState): PerPotentielState {
   };
 }
 
-function makeDefaultState(): PerPotentielState {
+function makeDefaultState(options: PerPotentielStateOptions = {}): PerPotentielState {
   return normalizeState({
     step: 1,
     mode: null,
@@ -138,10 +147,10 @@ function makeDefaultState(): PerPotentielState {
     projectionNDeclarant2: { ...EMPTY_DECLARANT },
     versementEnvisage: 0,
     mutualisationConjoints: false,
-  });
+  }, options);
 }
 
-function loadSession(): PerPotentielState | null {
+function loadSession(options: PerPotentielStateOptions = {}): PerPotentielState | null {
   try {
     const raw = sessionStorage.getItem(SESSION_KEY);
     if (!raw) return null;
@@ -150,7 +159,7 @@ function loadSession(): PerPotentielState | null {
       return null;
     }
     return normalizeState({
-      ...makeDefaultState(),
+      ...makeDefaultState(options),
       ...parsed,
       revenusN1Declarant1: { ...EMPTY_DECLARANT, ...parsed.revenusN1Declarant1 },
       revenusN1Declarant2: { ...EMPTY_DECLARANT, ...parsed.revenusN1Declarant2 },
@@ -158,7 +167,7 @@ function loadSession(): PerPotentielState | null {
       projectionNDeclarant2: { ...EMPTY_DECLARANT, ...parsed.projectionNDeclarant2 },
       children: normalizePerChildren(parsed.children),
       projectionChildren: normalizePerChildren(parsed.projectionChildren),
-    });
+    }, options);
   } catch {
     return null;
   }
@@ -226,8 +235,18 @@ export interface UsePerPotentielReturn {
   isCouple: boolean;
 }
 
-export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielReturn {
-  const [state, setState] = useState<PerPotentielState>(() => loadSession() ?? makeDefaultState());
+export interface UsePerPotentielOptions {
+  simplifiedMode?: boolean;
+}
+
+export function usePerPotentiel(
+  fiscalContext: FiscalContext,
+  options: UsePerPotentielOptions = {},
+): UsePerPotentielReturn {
+  const simplifiedMode = options.simplifiedMode === true;
+  const [state, setState] = useState<PerPotentielState>(
+    () => loadSession({ simplifiedMode }) ?? makeDefaultState({ simplifiedMode }),
+  );
   const years = useMemo(() => getPerWorkflowYears(fiscalContext), [fiscalContext]);
   const visibleSteps = useMemo(
     () => buildVisibleSteps(state.mode, state.historicalBasis, state.needsCurrentYearEstimate),
@@ -235,10 +254,25 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
   );
 
   const persist = useCallback((next: PerPotentielState) => {
-    const normalized = normalizeState(next);
+    const normalized = normalizeState(next, { simplifiedMode });
     setState(normalized);
     saveSession(normalized);
-  }, []);
+  }, [simplifiedMode]);
+
+  useEffect(() => {
+    if (!simplifiedMode) {
+      return;
+    }
+
+    setState((previous) => {
+      const normalized = normalizeState(previous, { simplifiedMode: true });
+      if (isPerSimplifiedPresetState(previous) && previous.step === normalized.step) {
+        return previous;
+      }
+      saveSession(normalized);
+      return normalized;
+    });
+  }, [simplifiedMode]);
 
   const setMode = useCallback((mode: PerMode) => {
     const nextBasis = mode === 'declaration-n1'
@@ -406,14 +440,14 @@ export function usePerPotentiel(fiscalContext: FiscalContext): UsePerPotentielRe
   }, [state, persist, visibleSteps]);
 
   const reset = useCallback(() => {
-    const fresh = makeDefaultState();
+    const fresh = makeDefaultState({ simplifiedMode });
     setState(fresh);
     try {
       sessionStorage.removeItem(SESSION_KEY);
     } catch {
       /* ignore */
     }
-  }, []);
+  }, [simplifiedMode]);
 
   const canGoNext = useMemo(() => {
     if (state.step !== 1) {

--- a/src/features/per/styles/steps.css
+++ b/src/features/per/styles/steps.css
@@ -53,6 +53,14 @@
   transform: translateY(-1px);
 }
 
+.per-mode-card--locked,
+.per-mode-card--locked:hover {
+  cursor: default;
+  border-color: var(--color-c8);
+  box-shadow: none;
+  transform: none;
+}
+
 .per-mode-card--selected {
   border-color: var(--color-c2);
   background: color-mix(in srgb, var(--color-c4) 48%, #FFFFFF);
@@ -138,6 +146,15 @@
   border-color: var(--color-c3);
   background: #FFFFFF;
   transform: translateY(-1px);
+}
+
+.per-mode-doc-card--locked,
+.per-mode-doc-card--locked:hover {
+  cursor: default;
+  border-color: var(--color-c8);
+  background: #FFFFFF;
+  box-shadow: none;
+  transform: none;
 }
 
 .per-mode-doc-card.is-selected {

--- a/src/features/per/utils/perSimplifiedMode.test.ts
+++ b/src/features/per/utils/perSimplifiedMode.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyPerSimplifiedPreset,
+  isPerSimplifiedPresetState,
+  PER_SIMPLIFIED_PRESET,
+} from './perSimplifiedMode';
+
+describe('perSimplifiedMode', () => {
+  it('force le parcours simplifié sur le contrôle avant versement depuis l’avis courant', () => {
+    const state = applyPerSimplifiedPreset({
+      step: 4,
+      mode: 'declaration-n1' as const,
+      historicalBasis: 'previous-avis-plus-n1' as const,
+      needsCurrentYearEstimate: true,
+    });
+
+    expect(state).toMatchObject(PER_SIMPLIFIED_PRESET);
+    expect(state.step).toBe(4);
+    expect(isPerSimplifiedPresetState(state)).toBe(true);
+  });
+
+  it('détecte un état qui ne correspond pas au preset simplifié', () => {
+    expect(isPerSimplifiedPresetState({
+      mode: 'versement-n',
+      historicalBasis: 'previous-avis-plus-n1',
+      needsCurrentYearEstimate: false,
+    })).toBe(false);
+  });
+});

--- a/src/features/per/utils/perSimplifiedMode.ts
+++ b/src/features/per/utils/perSimplifiedMode.ts
@@ -1,0 +1,26 @@
+import type { PerHistoricalBasis } from '../../../engine/per';
+
+type PerSimplifiableState = {
+  mode: 'versement-n' | 'declaration-n1' | null;
+  historicalBasis: PerHistoricalBasis | null;
+  needsCurrentYearEstimate: boolean;
+};
+
+export const PER_SIMPLIFIED_PRESET = {
+  mode: 'versement-n',
+  historicalBasis: 'current-avis',
+  needsCurrentYearEstimate: false,
+} as const satisfies PerSimplifiableState;
+
+export function applyPerSimplifiedPreset<T extends PerSimplifiableState>(state: T): T {
+  return {
+    ...state,
+    ...PER_SIMPLIFIED_PRESET,
+  };
+}
+
+export function isPerSimplifiedPresetState(state: PerSimplifiableState): boolean {
+  return state.mode === PER_SIMPLIFIED_PRESET.mode
+    && state.historicalBasis === PER_SIMPLIFIED_PRESET.historicalBasis
+    && state.needsCurrentYearEstimate === PER_SIMPLIFIED_PRESET.needsCurrentYearEstimate;
+}


### PR DESCRIPTION
## Description
Verrouille le mode simplifié de `/sim/per/potentiel` sur le parcours attendu : contrôle du potentiel avant versement, avis IR courant disponible, projection de l’année en cours désactivée.

## Changements
- Ajout d’un preset PER simplifié partagé et testé.
- Forçage du preset dans `usePerPotentiel`, y compris après session persistée ou bascule expert/simplifié.
- Affichage d’un écran `Mode` verrouillé et explicite en mode simplifié.
- Conservation du parcours complet en mode expert.
- Ajout des tests ciblés sur le preset, l’écran Mode et l’intégration du hook.

## Fonctionnalités
- En mode simplifié, l’utilisateur part directement du parcours `Contrôle du potentiel avant versement` + `Avis IR 2026 disponible` + projection désactivée.
- Les anciens choix persistés ne peuvent plus dévier le parcours simplifié.
- En mode expert, les choix de parcours restent disponibles comme avant.

## Tests effectués
- [x] `npm run lint` passe
- [x] `npm run typecheck` passe
- [x] `npm test` passe
- [x] `npm run build` passe
- [x] `npm run check` passe (si utilisé comme agrégat)
- [x] `powershell -ExecutionPolicy Bypass -File .\scripts\pre-merge-check.ps1` passe

## Notes
`npm run check` remonte uniquement l’avertissement non bloquant existant sur la taille de `usePerPotentiel.ts`.

## Checklist
- [x] Pas de push direct sur `main`
- [x] Pas de fichiers temporaires ajoutés à la racine
- [x] Documentation mise à jour si nécessaire