### PR TITLE
fix(per): rétablir le conjoint sur versement n

### DIFF
--- a/src/features/per/components/potentiel/PerPotentielContextSidebar.test.tsx
+++ b/src/features/per/components/potentiel/PerPotentielContextSidebar.test.tsx
@@ -147,6 +147,7 @@ describe('PerPotentielContextSidebar', () => {
         showAdjustedPotentiel
         fiscalPreviewTitle="Synthèse déclaration IR 2026"
         projectionPreviewTitle="Plafonds projetés"
+        showProjectedPlafondCalcule
         parcoursPills={[{ label: 'Avis IR 2025', on: true }]}
         totalAvisIrD1={11111}
         totalAvisIrD2={7777}
@@ -184,6 +185,7 @@ describe('PerPotentielContextSidebar', () => {
         showAdjustedPotentiel={false}
         fiscalPreviewTitle="Estimation fiscale 2026"
         projectionPreviewTitle="Plafonds projetés"
+        showProjectedPlafondCalcule
         parcoursPills={[{ label: 'Avis IR 2025', on: true }]}
         totalAvisIrD1={11111}
         totalAvisIrD2={7777}
@@ -206,6 +208,7 @@ describe('PerPotentielContextSidebar', () => {
         showAdjustedPotentiel
         fiscalPreviewTitle="Contrôle versement 2026"
         projectionPreviewTitle="Plafonds projetés"
+        showProjectedPlafondCalcule
         parcoursPills={[{ label: 'Avis IR 2025', on: true }]}
         totalAvisIrD1={11111}
         totalAvisIrD2={7777}
@@ -218,5 +221,28 @@ describe('PerPotentielContextSidebar', () => {
     expect(html).toContain(fmtCurrency(3210));
     expect(html).not.toContain(fmtCurrency(11111));
     expect(html).not.toContain("163 quatervicies issu de l'avis IR");
+  });
+
+  it('masque le plafond calculé quand les revenus projetés ne sont pas renseignés', () => {
+    const html = renderToStaticMarkup(
+      <PerPotentielContextSidebar
+        step={3}
+        isCouple
+        showRevenusPreview={false}
+        showAdjustedPotentiel
+        fiscalPreviewTitle="Contrôle versement 2026"
+        projectionPreviewTitle="Plafonds projetés"
+        showProjectedPlafondCalcule={false}
+        parcoursPills={[{ label: 'Avis IR 2026', on: true }]}
+        totalAvisIrD1={11111}
+        totalAvisIrD2={7777}
+        result={result}
+      />,
+    );
+
+    expect(html).toContain('Plafond calculé');
+    expect(html).toContain('À déterminer');
+    expect(html).not.toContain(fmtCurrency(2400));
+    expect(html).not.toContain(fmtCurrency(1400));
   });
 });

--- a/src/features/per/components/potentiel/PerPotentielContextSidebar.tsx
+++ b/src/features/per/components/potentiel/PerPotentielContextSidebar.tsx
@@ -9,6 +9,7 @@ interface PerPotentielContextSidebarProps {
   showAdjustedPotentiel: boolean;
   fiscalPreviewTitle: string;
   projectionPreviewTitle: string;
+  showProjectedPlafondCalcule: boolean;
   parcoursPills: Array<{ label: string; on: boolean }>;
   totalAvisIrD1: number;
   totalAvisIrD2: number;
@@ -127,6 +128,7 @@ export function PerPotentielContextSidebar({
   showAdjustedPotentiel,
   fiscalPreviewTitle,
   projectionPreviewTitle,
+  showProjectedPlafondCalcule,
   parcoursPills,
   totalAvisIrD1,
   totalAvisIrD2,
@@ -179,7 +181,12 @@ export function PerPotentielContextSidebar({
       { label: 'Reliquat N-2', value: fmtCurrency(result.projectionAvisSuivant.declarant1.nonUtiliseN2) },
       { label: 'Reliquat N-1', value: fmtCurrency(result.projectionAvisSuivant.declarant1.nonUtiliseN1) },
       { label: 'Reliquat N', value: fmtCurrency(result.projectionAvisSuivant.declarant1.nonUtiliseN) },
-      { label: 'Plafond calculé', value: fmtCurrency(result.projectionAvisSuivant.declarant1.plafondCalculeN) },
+      {
+        label: 'Plafond calculé',
+        value: showProjectedPlafondCalcule
+          ? fmtCurrency(result.projectionAvisSuivant.declarant1.plafondCalculeN)
+          : 'À déterminer',
+      },
       { label: 'Total', value: fmtCurrency(result.projectionAvisSuivant.declarant1.plafondTotal) },
     ]
     : [];
@@ -188,7 +195,12 @@ export function PerPotentielContextSidebar({
       { label: 'Reliquat N-2', value: fmtCurrency(result.projectionAvisSuivant.declarant2.nonUtiliseN2) },
       { label: 'Reliquat N-1', value: fmtCurrency(result.projectionAvisSuivant.declarant2.nonUtiliseN1) },
       { label: 'Reliquat N', value: fmtCurrency(result.projectionAvisSuivant.declarant2.nonUtiliseN) },
-      { label: 'Plafond calculé', value: fmtCurrency(result.projectionAvisSuivant.declarant2.plafondCalculeN) },
+      {
+        label: 'Plafond calculé',
+        value: showProjectedPlafondCalcule
+          ? fmtCurrency(result.projectionAvisSuivant.declarant2.plafondCalculeN)
+          : 'À déterminer',
+      },
       { label: 'Total', value: fmtCurrency(result.projectionAvisSuivant.declarant2.plafondTotal) },
     ]
     : [];

--- a/src/features/per/components/potentiel/PerPotentielSimulator.test.tsx
+++ b/src/features/per/components/potentiel/PerPotentielSimulator.test.tsx
@@ -77,13 +77,17 @@ vi.mock('./steps/SituationFiscaleStep', () => ({
     showFoyerCard,
     showIncomeCard,
     situationFamiliale,
+    isCouple,
+    mutualisationConjoints,
   }: {
     showFoyerCard: boolean;
     showIncomeCard: boolean;
     situationFamiliale: 'celibataire' | 'marie';
+    isCouple: boolean;
+    mutualisationConjoints: boolean;
   }) => (
     <div>
-      Situation step {showFoyerCard ? 'foyer visible' : 'foyer masqué'} {showIncomeCard ? 'revenus visibles' : 'revenus masqués'} {situationFamiliale}
+      Situation step {showFoyerCard ? 'foyer visible' : 'foyer masqué'} {showIncomeCard ? 'revenus visibles' : 'revenus masqués'} {situationFamiliale} {isCouple ? 'couple' : 'solo'} {mutualisationConjoints ? '6QR oui' : '6QR non'}
     </div>
   ),
 }));
@@ -96,10 +100,12 @@ vi.mock('./PerPotentielContextSidebar', () => ({
   PerPotentielContextSidebar: ({
     totalAvisIrD1,
     totalAvisIrD2,
+    showProjectedPlafondCalcule,
   }: {
     totalAvisIrD1: number;
     totalAvisIrD2: number;
-  }) => <div>Sidebar contexte {totalAvisIrD1} / {totalAvisIrD2}</div>,
+    showProjectedPlafondCalcule: boolean;
+  }) => <div>Sidebar contexte {totalAvisIrD1} / {totalAvisIrD2} {showProjectedPlafondCalcule ? 'plafond connu' : 'plafond à déterminer'}</div>,
 }));
 
 import PerPotentielSimulator from './PerPotentielSimulator';
@@ -266,7 +272,7 @@ describe('PerPotentielSimulator', () => {
 
     const html = renderToStaticMarkup(<PerPotentielSimulator />);
 
-    expect(html).toContain('Situation step foyer visible revenus visibles marie');
+    expect(html).toContain('Situation step foyer visible revenus visibles marie couple 6QR oui');
   });
 
   it('affiche un Versement N simplifié avec avis IR 2026 sans projection', () => {
@@ -283,10 +289,11 @@ describe('PerPotentielSimulator', () => {
     const html = renderToStaticMarkup(<PerPotentielSimulator />);
 
     expect(html).toContain('Versement N');
-    expect(html).toContain('Situation step foyer masqué revenus masqués celibataire');
+    expect(html).toContain('Situation step foyer masqué revenus masqués celibataire couple 6QR non');
+    expect(html).toContain('plafond à déterminer');
   });
 
-  it('masque les revenus sur Versement N quand la projection est inactive', () => {
+  it('masque les revenus sur Versement N mais garde D2 quand un avis conjoint existe', () => {
     mockUsePerPotentiel.mockReturnValue({
       ...makeHookReturn(4),
       state: {
@@ -299,7 +306,25 @@ describe('PerPotentielSimulator', () => {
 
     const html = renderToStaticMarkup(<PerPotentielSimulator />);
 
-    expect(html).toContain('Situation step foyer masqué revenus masqués marie');
+    expect(html).toContain('Situation step foyer masqué revenus masqués marie couple 6QR non');
+    expect(html).toContain('plafond à déterminer');
+  });
+
+  it('reste en solo sur Versement N sans projection si aucun avis IR D2 significatif n’existe', () => {
+    mockUsePerPotentiel.mockReturnValue({
+      ...makeHookReturn(3),
+      state: {
+        ...makeHookState(3),
+        historicalBasis: 'current-avis',
+        needsCurrentYearEstimate: false,
+        avisIr2: null,
+      },
+      visibleSteps: [1, 2, 3],
+    });
+
+    const html = renderToStaticMarkup(<PerPotentielSimulator />);
+
+    expect(html).toContain('Situation step foyer masqué revenus masqués celibataire solo 6QR non');
   });
 
   it('renomme la tab déclaration en Revenus 2025 et masque la synthèse', () => {

--- a/src/features/per/components/potentiel/PerPotentielSimulator.tsx
+++ b/src/features/per/components/potentiel/PerPotentielSimulator.tsx
@@ -13,6 +13,7 @@ import '@/styles/sim/index.css';
 import { onResetEvent } from '../../../../utils/reset';
 import { usePerPotentiel, type WizardStep } from '../../hooks/usePerPotentiel';
 import { usePerPotentielExportHandlers } from '../../hooks/usePerPotentielExportHandlers';
+import { hasAvisIrDeclarant, sumAvisIrPlafonds } from '../../utils/perAvisIrPlafonds';
 import { getPerWorkflowYears } from '../../utils/perWorkflowYears';
 import ModeStep from './steps/ModeStep';
 import AvisIrStep from './steps/AvisIrStep';
@@ -26,19 +27,6 @@ type StepMeta = {
   shortLabel: string;
   title: string;
 };
-
-const sumAvisIrPlafonds = (
-  avis: {
-    nonUtiliseAnnee1?: number;
-    nonUtiliseAnnee2?: number;
-    nonUtiliseAnnee3?: number;
-    plafondCalcule?: number;
-  } | null,
-): number =>
-  (avis?.nonUtiliseAnnee1 ?? 0)
-  + (avis?.nonUtiliseAnnee2 ?? 0)
-  + (avis?.nonUtiliseAnnee3 ?? 0)
-  + (avis?.plafondCalcule ?? 0);
 
 const DEFAULT_INCOME_FILTERS: PerIncomeFilters = {
   pension: false,
@@ -192,15 +180,17 @@ export default function PerPotentielSimulator(): React.ReactElement {
   const parcoursPills = buildPills();
   const totalAvisIrD1 = sumAvisIrPlafonds(state.avisIr);
   const totalAvisIrD2 = sumAvisIrPlafonds(state.avisIr2);
+  const hasAvisIrD2 = hasAvisIrDeclarant(state.avisIr2);
   const revenusIsCouple = state.situationFamiliale === 'marie';
   const projectionIsCouple = state.projectionSituationFamiliale === 'marie';
+  const versementNIsCouple = projectionIsCouple || (!state.needsCurrentYearEstimate && hasAvisIrD2);
   const usesProjectionFoyer = state.mode === 'versement-n' && (
     state.historicalBasis === 'current-avis'
       ? state.step >= 3
       : state.step >= 4
   );
   const activeIsCouple = usesProjectionFoyer
-    ? projectionIsCouple || (!state.needsCurrentYearEstimate && Boolean(state.avisIr2))
+    ? versementNIsCouple
     : revenusIsCouple;
   const abat10CfgRoot = fiscalContext._raw_tax?.incomeTax?.abat10 ?? {};
   const abat10SalCfgCurrent: PerAbattementConfig = abat10CfgRoot.current ?? {};
@@ -215,6 +205,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
     || (state.historicalBasis === 'previous-avis-plus-n1' && state.step === 4)
   );
   const showProjectionDetailInputs = state.needsCurrentYearEstimate;
+  const showProjectedPlafondCalcule = isRevenusStep || showProjectionDetailInputs;
   const fiscalPreviewTitle = isRevenusStep
     ? `Synthèse déclaration IR ${years.currentTaxYear}`
     : (isVersementNStep && !showProjectionDetailInputs
@@ -375,7 +366,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   situationFamiliale={state.projectionSituationFamiliale}
                   isole={state.projectionIsole}
                   children={state.projectionChildren}
-                  isCouple={projectionIsCouple}
+                  isCouple={versementNIsCouple}
                   mutualisationConjoints={state.projectionMutualisationConjoints}
                   declarant1={state.projectionNDeclarant1}
                   declarant2={state.projectionNDeclarant2}
@@ -402,7 +393,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
                   situationFamiliale={state.projectionSituationFamiliale}
                   isole={state.projectionIsole}
                   children={state.projectionChildren}
-                  isCouple={projectionIsCouple}
+                  isCouple={versementNIsCouple}
                   mutualisationConjoints={state.projectionMutualisationConjoints}
                   declarant1={state.projectionNDeclarant1}
                   declarant2={state.projectionNDeclarant2}
@@ -435,6 +426,7 @@ export default function PerPotentielSimulator(): React.ReactElement {
             showAdjustedPotentiel={isRevenusStep || isVersementNStep}
             fiscalPreviewTitle={fiscalPreviewTitle}
             projectionPreviewTitle={projectionPreviewTitle}
+            showProjectedPlafondCalcule={showProjectedPlafondCalcule}
             parcoursPills={parcoursPills}
             totalAvisIrD1={totalAvisIrD1}
             totalAvisIrD2={totalAvisIrD2}

--- a/src/features/per/hooks/usePerPotentiel.ts
+++ b/src/features/per/hooks/usePerPotentiel.ts
@@ -16,6 +16,7 @@ import type {
 } from '@/engine/per';
 import type { FiscalContext } from '@/hooks/useFiscalContext';
 import { getAvisReferenceYears, getPerWorkflowYears } from '../utils/perWorkflowYears';
+import { hasAvisIrDeclarant } from '../utils/perAvisIrPlafonds';
 import type { PerChildDraft } from '../utils/perParts';
 import { shouldUseProjectionForCalculation } from '../utils/perProjectionScope';
 import { resolvePerCalculationYear } from '../utils/perCalculationYear';
@@ -154,7 +155,19 @@ export function usePerPotentiel(
       plafondCalcule: 0,
       anneeRef: avisContext.incomeYear,
     };
-    persist({ ...state, [key]: { ...current, ...patch, anneeRef: current.anneeRef || avisContext.incomeYear } });
+    const couplePatch = decl === 2
+      ? {
+        situationFamiliale: 'marie' as const,
+        projectionSituationFamiliale: 'marie' as const,
+        projectionFoyerEdited: true,
+      }
+      : {};
+
+    persist({
+      ...state,
+      ...couplePatch,
+      [key]: { ...current, ...patch, anneeRef: current.anneeRef || avisContext.incomeYear },
+    });
   }, [state, persist, years]);
 
   const updateSituation = useCallback((patch: PerSituationPatch) => {
@@ -282,7 +295,7 @@ export function usePerPotentiel(
 
     const forceProjectionCouple = useProjection
       && !state.needsCurrentYearEstimate
-      && Boolean(avisOverride?.avisIr2 ?? state.avisIr2);
+      && hasAvisIrDeclarant(avisOverride?.avisIr2 ?? state.avisIr2);
 
     return {
       mode: state.mode,

--- a/src/features/per/utils/perAvisIrPlafonds.test.ts
+++ b/src/features/per/utils/perAvisIrPlafonds.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { hasAvisIrDeclarant, hasAvisIrPlafondsData, sumAvisIrPlafonds } from './perAvisIrPlafonds';
+
+describe('perAvisIrPlafonds', () => {
+  it('additionne les reliquats et le plafond calculé', () => {
+    expect(sumAvisIrPlafonds({
+      nonUtiliseAnnee1: 1000,
+      nonUtiliseAnnee2: 2000,
+      nonUtiliseAnnee3: 3000,
+      plafondCalcule: 4000,
+      anneeRef: 2025,
+    })).toBe(10000);
+  });
+
+  it('détecte uniquement un avis IR conjoint significatif', () => {
+    expect(hasAvisIrPlafondsData(null)).toBe(false);
+    expect(hasAvisIrPlafondsData({
+      nonUtiliseAnnee1: 0,
+      nonUtiliseAnnee2: 0,
+      nonUtiliseAnnee3: 0,
+      plafondCalcule: 0,
+      anneeRef: 2025,
+    })).toBe(false);
+    expect(hasAvisIrPlafondsData({
+      nonUtiliseAnnee1: 0,
+      nonUtiliseAnnee2: 0,
+      nonUtiliseAnnee3: 0,
+      plafondCalcule: 1,
+      anneeRef: 2025,
+    })).toBe(true);
+  });
+
+  it('considère un avis IR D2 saisi comme un signal de conjoint même à zéro', () => {
+    expect(hasAvisIrDeclarant(null)).toBe(false);
+    expect(hasAvisIrDeclarant({
+      nonUtiliseAnnee1: 0,
+      nonUtiliseAnnee2: 0,
+      nonUtiliseAnnee3: 0,
+      plafondCalcule: 0,
+      anneeRef: 2025,
+    })).toBe(true);
+  });
+});

--- a/src/features/per/utils/perAvisIrPlafonds.ts
+++ b/src/features/per/utils/perAvisIrPlafonds.ts
@@ -1,0 +1,16 @@
+import type { AvisIrPlafonds } from '@/engine/per';
+
+export function sumAvisIrPlafonds(avis: AvisIrPlafonds | null | undefined): number {
+  return (avis?.nonUtiliseAnnee1 ?? 0)
+    + (avis?.nonUtiliseAnnee2 ?? 0)
+    + (avis?.nonUtiliseAnnee3 ?? 0)
+    + (avis?.plafondCalcule ?? 0);
+}
+
+export function hasAvisIrPlafondsData(avis: AvisIrPlafonds | null | undefined): boolean {
+  return sumAvisIrPlafonds(avis) > 0;
+}
+
+export function hasAvisIrDeclarant(avis: AvisIrPlafonds | null | undefined): boolean {
+  return avis != null;
+}

--- a/src/utils/reset.test.ts
+++ b/src/utils/reset.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { onResetEvent, triggerPageReset } from './reset';
+
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+const originalSessionStorage = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage');
+
+function restoreGlobalProperty(key: 'window' | 'sessionStorage', descriptor: PropertyDescriptor | undefined): void {
+  if (descriptor) {
+    Object.defineProperty(globalThis, key, descriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(globalThis, key);
+}
+
+describe('reset', () => {
+  let removedKeys: string[];
+
+  beforeEach(() => {
+    const eventTarget = new EventTarget();
+    removedKeys = [];
+    const storage: Storage = {
+      get length() {
+        return 0;
+      },
+      clear: () => undefined,
+      getItem: () => null,
+      key: () => null,
+      removeItem: (key: string) => {
+        removedKeys.push(key);
+      },
+      setItem: () => undefined,
+    };
+
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: eventTarget,
+    });
+    Object.defineProperty(globalThis, 'sessionStorage', {
+      configurable: true,
+      value: storage,
+    });
+  });
+
+  afterEach(() => {
+    restoreGlobalProperty('window', originalWindow);
+    restoreGlobalProperty('sessionStorage', originalSessionStorage);
+  });
+
+  it('déclenche un reset ciblé depuis la topbar', () => {
+    const handler = vi.fn();
+    const off = onResetEvent(handler);
+
+    triggerPageReset('per-potentiel');
+
+    expect(removedKeys).toContain('ser1:sim:per-potentiel');
+    expect(handler).toHaveBeenCalledWith({ simId: 'per-potentiel' });
+
+    off();
+    triggerPageReset('per-potentiel');
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Description
Corrige le parcours `/sim/per/potentiel` lorsque le mode simplifié repart d'un avis IR avec deux déclarants : l'onglet `Versement N` réaffiche désormais le déclarant 2 et permet d'activer la mutualisation des plafonds.

## Changements
- Alignement de l'état PER : la saisie d'un avis IR déclarant 2 force le foyer/projection en couple pour les étapes de versement.
- Ajout d'un helper `perAvisIrPlafonds` pour centraliser la détection et la somme des plafonds issus de l'avis IR.
- Ajustement de la sidebar `Plafonds projetés` pour afficher `À déterminer` quand les revenus projetés ne sont pas saisissables.
- Couverture de tests sur le reset topbar, le conjoint en `Versement N`, et l'affichage du plafond projeté.

## Fonctionnalités
- Le déclarant 2 reste disponible sur `Versement N` après saisie dans l'avis IR, y compris en mode simplifié.
- La case de mutualisation des plafonds `6QR` devient activable dans ce cas.
- La carte `Plafonds projetés` évite d'afficher un plafond calculé trompeur sans revenus projetés.

## Tests effectués
- [x] `npm run lint` passe
- [x] `npm run typecheck` passe
- [x] `npm test` passe
- [x] `npm run build` passe
- [x] `npm run check` passe (si utilisé comme agrégat)
- [x] `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\pre-merge-check.ps1` passe

## Notes
`npm run check` couvre lint, CSS, fiscal hardcode, architecture, dépendances circulaires, typecheck, tests et build. Pas de migration ni de changement moteur fiscal. `PerPotentielSimulator.tsx` reste dans la zone warning clean-code (~416 lignes), sans nouvelle responsabilité lourde ajoutée.

## Checklist
- [x] Pas de push direct sur `main`
- [x] Pas de fichiers temporaires ajoutés à la racine
- [x] Documentation mise à jour si nécessaire